### PR TITLE
Restore syncer code with modular interface design

### DIFF
--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -1,0 +1,26 @@
+name: Build Syncer Image
+
+permissions:
+  packages: write
+
+on:
+  push:
+    branches:
+    - main
+    - 'release-*'
+    tags:
+    - 'v*'
+
+jobs:
+  syncer-image:
+    name: Build Syncer Image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: v1.19
+
+      # Build and push multi-arch supported syncer image, tagged with the commit SHA and the branch name.
+      - uses: imjasonh/setup-ko@v0.6
+      - run: ko publish -B ./cmd/syncer --platform linux/amd64,linux/ppc64le,linux/arm64 -t $(git rev-parse --short "$GITHUB_SHA"),${{ github.ref_name }}

--- a/cmd/syncer/cmd/dns.go
+++ b/cmd/syncer/cmd/dns.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	synceroptions "github.com/kcp-dev/kcp/cmd/syncer/options"
+	"github.com/kcp-dev/kcp/pkg/dns/plugin/nsmap"
+	"github.com/kcp-dev/kcp/third_party/coredns/coremain"
+)
+
+func NewDNSCommand() *cobra.Command {
+	options := synceroptions.NewDNSOptions()
+	dnsCommand := &cobra.Command{
+		Use:   "dns",
+		Short: "Manage kcp dns server",
+	}
+
+	startCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the kcp dns server",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Complete(); err != nil {
+				return err
+			}
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			nsmap.ConfigMapName = options.ConfigMapName
+
+			coremain.Start()
+			return nil
+		},
+	}
+	options.AddFlags(startCmd.Flags())
+
+	dnsCommand.AddCommand(startCmd)
+
+	return dnsCommand
+}

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/tools/clientcmd"
+	logsapiv1 "k8s.io/component-base/logs/api/v1"
+	"k8s.io/component-base/version"
+	"k8s.io/klog/v2"
+
+	synceroptions "github.com/kcp-dev/kcp/cmd/syncer/options"
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	"github.com/kcp-dev/kcp/pkg/syncer"
+)
+
+const numThreads = 2
+
+func NewSyncerCommand() *cobra.Command {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	options := synceroptions.NewOptions()
+	syncerCommand := &cobra.Command{
+		Use:   "syncer",
+		Short: "Synchronizes resources in `kcp` assigned to the clusters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := logsapiv1.ValidateAndApply(options.Logs, kcpfeatures.DefaultFeatureGate); err != nil {
+				return err
+			}
+			if err := options.Complete(); err != nil {
+				return err
+			}
+
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			ctx := genericapiserver.SetupSignalContext()
+			if err := Run(ctx, options); err != nil {
+				return err
+			}
+
+			<-ctx.Done()
+
+			return nil
+		},
+	}
+
+	options.AddFlags(syncerCommand.Flags())
+
+	if v := version.Get().String(); len(v) == 0 {
+		syncerCommand.Version = "<unknown>"
+	} else {
+		syncerCommand.Version = v
+	}
+
+	syncerCommand.AddCommand(NewDNSCommand())
+
+	return syncerCommand
+}
+
+func Run(ctx context.Context, options *synceroptions.Options) error {
+	logger := klog.FromContext(ctx)
+	logger.Info("syncing", "resource-types", options.SyncedResourceTypes)
+
+	kcpConfigOverrides := &clientcmd.ConfigOverrides{
+		CurrentContext: options.FromContext,
+	}
+	upstreamConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.FromKubeconfig},
+		kcpConfigOverrides).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	upstreamConfig.QPS = options.QPS
+	upstreamConfig.Burst = options.Burst
+
+	downstreamConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: options.ToContext,
+		}).ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	downstreamConfig.QPS = options.QPS
+	downstreamConfig.Burst = options.Burst
+
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		return errors.New("missing environment variable: NAMESPACE")
+	}
+
+	return syncer.StartSyncer(
+		ctx,
+		&syncer.SyncerConfig{
+			UpstreamConfig:                upstreamConfig,
+			DownstreamConfig:              downstreamConfig,
+			ResourcesToSync:               sets.New[string](options.SyncedResourceTypes...),
+			SyncTargetPath:                logicalcluster.NewPath(options.FromClusterPath),
+			SyncTargetName:                options.SyncTargetName,
+			SyncTargetUID:                 options.SyncTargetUID,
+			DNSImage:                      options.DNSImage,
+			DownstreamNamespaceCleanDelay: options.DownstreamNamespaceCleanDelay,
+		},
+		numThreads,
+		options.APIImportPollInterval,
+		namespace,
+	)
+}

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"k8s.io/component-base/cli"
+	_ "k8s.io/component-base/logs/json/register"
+
+	"github.com/kcp-dev/kcp/cmd/syncer/cmd"
+)
+
+func main() {
+	syncerCommand := cmd.NewSyncerCommand()
+	code := cli.Run(syncerCommand)
+	os.Exit(code)
+}

--- a/cmd/syncer/options/dnsoptions.go
+++ b/cmd/syncer/options/dnsoptions.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+)
+
+type DNSOptions struct {
+	ConfigMapName string
+}
+
+func NewDNSOptions() *DNSOptions {
+	return &DNSOptions{}
+}
+
+func (options *DNSOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&options.ConfigMapName, "configmap-name", options.ConfigMapName, "name of the ConfigMap containing namespace mappings")
+}
+
+func (options *DNSOptions) Complete() error {
+	return nil
+}
+
+func (options *DNSOptions) Validate() error {
+	if options.ConfigMapName == "" {
+		return errors.New("--configmap-name is required")
+	}
+
+	return nil
+}

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/component-base/logs"
+	logsapiv1 "k8s.io/component-base/logs/api/v1"
+
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+type Options struct {
+	QPS                           float32
+	Burst                         int
+	FromKubeconfig                string
+	FromContext                   string
+	FromClusterPath               string
+	ToKubeconfig                  string
+	ToContext                     string
+	SyncTargetName                string
+	SyncTargetUID                 string
+	Logs                          *logs.Options
+	SyncedResourceTypes           []string
+	DNSImage                      string
+	DownstreamNamespaceCleanDelay time.Duration
+
+	APIImportPollInterval time.Duration
+}
+
+func NewOptions() *Options {
+	// Default to -v=2
+	logsOptions := logs.NewOptions()
+	logsOptions.Verbosity = logsapiv1.VerbosityLevel(2)
+
+	return &Options{
+		QPS:                           30,
+		Burst:                         20,
+		SyncedResourceTypes:           []string{},
+		Logs:                          logsOptions,
+		APIImportPollInterval:         1 * time.Minute,
+		DownstreamNamespaceCleanDelay: 30 * time.Second,
+	}
+}
+
+func (options *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.Float32Var(&options.QPS, "qps", options.QPS, "QPS to use when talking to API servers.")
+	fs.IntVar(&options.Burst, "burst", options.Burst, "Burst to use when talking to API servers.")
+	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
+	fs.StringVar(&options.FromContext, "from-context", options.FromContext, "Context to use in the Kubeconfig file for -from cluster, instead of the current context.")
+	fs.StringVar(&options.FromClusterPath, "from-cluster", options.FromClusterPath, "Path of the -from logical cluster.")
+	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
+	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
+	fs.StringVar(&options.SyncTargetName, "sync-target-name", options.SyncTargetName,
+		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", workloadv1alpha1.ClusterResourceStateLabelPrefix+"<ClusterID>"))
+	fs.StringVar(&options.SyncTargetUID, "sync-target-uid", options.SyncTargetUID, "The UID from the SyncTarget resource in KCP.")
+	fs.StringArrayVarP(&options.SyncedResourceTypes, "resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
+	fs.DurationVar(&options.APIImportPollInterval, "api-import-poll-interval", options.APIImportPollInterval, "Polling interval for API import.")
+	fs.Var(kcpfeatures.NewFlagValue(), "feature-gates", ""+
+		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
+		"Options are:\n"+strings.Join(kcpfeatures.KnownFeatures(), "\n")) // hide kube-only gates
+	fs.StringVar(&options.DNSImage, "dns-image", options.DNSImage, "kcp DNS server image.")
+	fs.DurationVar(&options.DownstreamNamespaceCleanDelay, "downstream-namespace-clean-delay", options.DownstreamNamespaceCleanDelay, "Time to wait before deleting a downstream namespace, defaults to 30s.")
+
+	logsapiv1.AddFlags(options.Logs, fs)
+}
+
+func (options *Options) Complete() error {
+	return nil
+}
+
+func (options *Options) Validate() error {
+	if options.FromClusterPath == "" {
+		return errors.New("--from-cluster is required")
+	}
+	if options.FromKubeconfig == "" {
+		return errors.New("--from-kubeconfig is required")
+	}
+	if options.SyncTargetUID == "" {
+		return errors.New("--sync-target-uid is required")
+	}
+	return nil
+}

--- a/docs/syncer-design.md
+++ b/docs/syncer-design.md
@@ -1,0 +1,28 @@
+# Syncer Architecture Overview
+
+This document describes the legacy syncer found on branch `main-pre-tmc-removal` and the high level design for a more modular implementation.
+
+## Legacy Layout
+
+The legacy syncer implementation lives under `cmd/syncer` and `pkg/syncer`. It contains a variety of controllers and helper packages:
+
+- **apiimporter.go** – imports API resources into a workload cluster.
+- **namespace**, **status**, **endpoints** – controllers for specific resource types.
+- **synctarget** – utilities for referencing `SyncTarget` objects.
+- **tunneler** – support for network tunnels used by the syncer.
+
+`StartSyncer` in `pkg/syncer/syncer.go` orchestrates initialization of informers, controllers and the optional DNS processor.
+
+## Modular Design
+
+New interfaces in `pkg/syncer/module` define pluggable components:
+
+- `ResourceSyncer` – starts resource synchronization.
+- `ConflictResolver` – resolves conflicts during sync.
+- `ErrorHandler` – handles generic errors.
+- `MetricsCollector` – collects metrics for monitoring.
+- `Logger` – abstracts logging.
+
+`Modules` aggregates implementations and provides defaults. `StartSyncer` now delegates to `startSyncerWithModules`, allowing callers to provide alternative implementations.
+
+This approach enables future extensions without changing the core syncer logic.

--- a/docs/syncer-legacy-analysis.md
+++ b/docs/syncer-legacy-analysis.md
@@ -1,0 +1,10 @@
+# Legacy Syncer Structure
+
+The `main-pre-tmc-removal` branch includes a full implementation of a syncer used for transparent multi-cluster scheduling. Important locations include:
+
+- `cmd/syncer` – CLI entry point and option parsing.
+- `pkg/syncer` – core library with controllers for namespace syncing, status updates and more.
+- `pkg/tunneler` – helpers for establishing a reverse tunnel from the SyncTarget back to KCP.
+- `test/e2e/syncer` – end-to-end tests for syncer functionality.
+
+`StartSyncer` sets up Kubernetes informers, waits for a `SyncTarget` to appear, then starts multiple controllers such as API importers and status synchronizers.

--- a/pkg/syncer/OWNERS
+++ b/pkg/syncer/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal
+reviewers:
+- jmprusi

--- a/pkg/syncer/apiimporter.go
+++ b/pkg/syncer/apiimporter.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/crdpuller"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	apiresourcev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apiresource/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned"
+	kcpclusterclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	apiresourceinformer "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/apiresource/v1alpha1"
+	workloadinformers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/workload/v1alpha1"
+	workloadv1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/workload/v1alpha1"
+)
+
+var clusterKind = reflect.TypeOf(workloadv1alpha1.SyncTarget{}).Name()
+
+const GVRForLocationIndexName = "GVRForLocation"
+
+func GetGVRForLocationIndexKey(location string, gvr metav1.GroupVersionResource) string {
+	return location + "$$" + gvr.String()
+}
+
+const LocationIndexName = "Location"
+
+func GetLocationIndexKey(location string) string {
+	return location
+}
+
+func clusterAsOwnerReference(obj *workloadv1alpha1.SyncTarget, controller bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: workloadv1alpha1.SchemeGroupVersion.String(),
+		Kind:       clusterKind,
+		Name:       obj.Name,
+		UID:        obj.UID,
+		Controller: &controller,
+	}
+}
+
+func NewAPIImporter(
+	upstreamConfig, downstreamConfig *rest.Config,
+	synctargetInformer workloadinformers.SyncTargetInformer,
+	apiImportInformer apiresourceinformer.APIResourceImportInformer,
+	resourcesToSync []string,
+	syncTargetPath logicalcluster.Path,
+	syncTargetName string,
+	syncTargetUID types.UID,
+) (*APIImporter, error) {
+	agent := fmt.Sprintf("kcp-workload-api-importer-%s-%s", syncTargetPath, syncTargetName)
+	upstreamConfig = rest.AddUserAgent(rest.CopyConfig(upstreamConfig), agent)
+	downstreamConfig = rest.AddUserAgent(rest.CopyConfig(downstreamConfig), agent)
+
+	kcpClusterClient, err := kcpclusterclientset.NewForConfig(upstreamConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kcpClient := kcpClusterClient.Cluster(syncTargetPath)
+
+	importIndexer := apiImportInformer.Informer().GetIndexer()
+
+	indexers := map[string]cache.IndexFunc{
+		GVRForLocationIndexName: func(obj interface{}) ([]string, error) {
+			if apiResourceImport, ok := obj.(*apiresourcev1alpha1.APIResourceImport); ok {
+				return []string{GetGVRForLocationIndexKey(apiResourceImport.Spec.Location, apiResourceImport.GVR())}, nil
+			}
+			return []string{}, nil
+		},
+		LocationIndexName: func(obj interface{}) ([]string, error) {
+			if apiResourceImport, ok := obj.(*apiresourcev1alpha1.APIResourceImport); ok {
+				return []string{GetLocationIndexKey(apiResourceImport.Spec.Location)}, nil
+			}
+			return []string{}, nil
+		},
+	}
+
+	// Ensure the indexers are only added if not already present.
+	for indexName := range importIndexer.GetIndexers() {
+		delete(indexers, indexName)
+	}
+	if len(indexers) > 0 {
+		if err := importIndexer.AddIndexers(indexers); err != nil {
+			return nil, fmt.Errorf("failed to add indexer for API Importer: %w", err)
+		}
+	}
+
+	crdClient, err := apiextensionsv1client.NewForConfig(downstreamConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating downstream apiextensions client: %w", err)
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(downstreamConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating downstream discovery client: %w", err)
+	}
+
+	schemaPuller, err := crdpuller.NewSchemaPuller(discoveryClient, crdClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &APIImporter{
+		kcpClient:                kcpClient,
+		resourcesToSync:          resourcesToSync,
+		apiresourceImportIndexer: importIndexer,
+		syncTargetLister:         synctargetInformer.Lister(),
+
+		syncTargetName: syncTargetName,
+		syncTargetUID:  syncTargetUID,
+		schemaPuller:   schemaPuller,
+	}, nil
+}
+
+type APIImporter struct {
+	kcpClient                kcpclientset.Interface
+	resourcesToSync          []string
+	apiresourceImportIndexer cache.Indexer
+	syncTargetLister         workloadv1alpha1listers.SyncTargetLister
+
+	syncTargetName string
+	syncTargetUID  types.UID
+	schemaPuller   schemaPuller
+	SyncedGVRs     map[string]metav1.GroupVersionResource
+}
+
+// schemaPuller allows pulling the API resources as CRDs
+// from a kubernetes cluster.
+type schemaPuller interface {
+	// PullCRDs allows pulling the resources named by their plural names
+	// and make them available as CRDs in the output map.
+	PullCRDs(context context.Context, resourceNames ...string) (map[schema.GroupResource]*apiextensionsv1.CustomResourceDefinition, error)
+}
+
+func (i *APIImporter) Start(ctx context.Context, pollInterval time.Duration) {
+	defer runtime.HandleCrash()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), "api-importer")
+	ctx = klog.NewContext(ctx, logger)
+
+	logger.Info("Starting API Importer")
+
+	go wait.UntilWithContext(ctx, func(innerCtx context.Context) {
+		i.ImportAPIs(innerCtx)
+	}, pollInterval)
+
+	<-ctx.Done()
+	i.Stop(ctx)
+}
+
+func (i *APIImporter) Stop(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	logger.Info("stopping API Importer")
+
+	objs, err := i.apiresourceImportIndexer.ByIndex(
+		LocationIndexName,
+		GetLocationIndexKey(i.syncTargetName),
+	)
+	if err != nil {
+		logger.Error(err, "error trying to list APIResourceImport objects")
+	}
+	for _, obj := range objs {
+		apiResourceImportToDelete := obj.(*apiresourcev1alpha1.APIResourceImport)
+		logger := logger.WithValues("apiResourceImport", apiResourceImportToDelete.Name)
+		err := i.kcpClient.ApiresourceV1alpha1().APIResourceImports().Delete(context.Background(), apiResourceImportToDelete.Name, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error(err, "error deleting APIResourceImport")
+		}
+	}
+}
+
+func (i *APIImporter) ImportAPIs(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	syncTarget, err := i.syncTargetLister.Get(i.syncTargetName)
+
+	if err != nil {
+		logger.Error(err, "error getting syncTarget")
+		return
+	}
+
+	if syncTarget.GetUID() != i.syncTargetUID {
+		logger.Error(fmt.Errorf("syncTarget uid is not correct, current: %s, required: %s", syncTarget.GetUID(), i.syncTargetUID), "error getting syncTarget")
+		return
+	}
+
+	// merge resourceToSync from synctarget with resourcesToSync set on the syncer's flag.
+	resourceToSyncSet := sets.New[string](i.resourcesToSync...)
+	for _, rs := range syncTarget.Status.SyncedResources {
+		resourceToSyncSet.Insert(fmt.Sprintf("%s.%s", rs.Resource, rs.Group))
+	}
+	// return if no resources to import
+	resourcesToSync := sets.List[string](resourceToSyncSet)
+	logger.V(2).Info("Importing APIs", "resourcesToImport", resourcesToSync)
+	if resourceToSyncSet.Len() == 0 {
+		return
+	}
+
+	crds, err := i.schemaPuller.PullCRDs(ctx, resourcesToSync...)
+	if err != nil {
+		logger.Error(err, "error pulling CRDs")
+		return
+	}
+
+	gvrsToSync := map[string]metav1.GroupVersionResource{}
+	for groupResource, pulledCrd := range crds {
+		crdVersion := pulledCrd.Spec.Versions[0]
+		gvr := metav1.GroupVersionResource{
+			Group:    pulledCrd.Spec.Group,
+			Version:  crdVersion.Name,
+			Resource: groupResource.Resource,
+		}
+		logger := logger.WithValues(
+			"group", gvr.Group,
+			"version", gvr.Version,
+			"resource", gvr.Resource,
+		)
+
+		objs, err := i.apiresourceImportIndexer.ByIndex(
+			GVRForLocationIndexName,
+			GetGVRForLocationIndexKey(i.syncTargetName, gvr),
+		)
+		if err != nil {
+			logger.Error(err, "error pulling CRDs")
+			continue
+		}
+		if len(objs) > 1 {
+			logger.Error(fmt.Errorf("there should be only one APIResourceImport but there was %d", len(objs)), "err importing APIs")
+			continue
+		}
+		if len(objs) == 1 {
+			apiResourceImport := objs[0].(*apiresourcev1alpha1.APIResourceImport).DeepCopy()
+			if err := apiResourceImport.Spec.SetSchema(crdVersion.Schema.OpenAPIV3Schema); err != nil {
+				logger.Error(err, "error setting schema")
+				continue
+			}
+			logger = logger.WithValues("apiResourceImport", apiResourceImport.Name)
+			logger.Info("updating APIResourceImport")
+			if _, err := i.kcpClient.ApiresourceV1alpha1().APIResourceImports().Update(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
+				logger.Error(err, "error updating APIResourceImport")
+				continue
+			}
+		} else {
+			apiResourceImportName := gvr.Resource + "." + i.syncTargetName + "." + gvr.Version + "."
+			if gvr.Group == "" {
+				apiResourceImportName += "core"
+			} else {
+				apiResourceImportName += gvr.Group
+			}
+			groupVersion := apiresourcev1alpha1.GroupVersion{
+				Group:   gvr.Group,
+				Version: gvr.Version,
+			}
+			apiResourceImport := &apiresourcev1alpha1.APIResourceImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: apiResourceImportName,
+					OwnerReferences: []metav1.OwnerReference{
+						clusterAsOwnerReference(syncTarget, true),
+					},
+					Annotations: map[string]string{
+						apiresourcev1alpha1.APIVersionAnnotation: groupVersion.APIVersion(),
+					},
+				},
+				Spec: apiresourcev1alpha1.APIResourceImportSpec{
+					Location:             i.syncTargetName,
+					SchemaUpdateStrategy: apiresourcev1alpha1.UpdateUnpublished,
+					CommonAPIResourceSpec: apiresourcev1alpha1.CommonAPIResourceSpec{
+						GroupVersion: apiresourcev1alpha1.GroupVersion{
+							Group:   gvr.Group,
+							Version: gvr.Version,
+						},
+						Scope:                         pulledCrd.Spec.Scope,
+						CustomResourceDefinitionNames: pulledCrd.Spec.Names,
+						SubResources:                  *(&apiresourcev1alpha1.SubResources{}).ImportFromCRDVersion(&crdVersion),
+						ColumnDefinitions:             *(&apiresourcev1alpha1.ColumnDefinitions{}).ImportFromCRDVersion(&crdVersion),
+					},
+				},
+			}
+			if err := apiResourceImport.Spec.SetSchema(crdVersion.Schema.OpenAPIV3Schema); err != nil {
+				logger.Error(err, "error setting schema")
+				continue
+			}
+			if value, found := pulledCrd.Annotations[apiextensionsv1.KubeAPIApprovedAnnotation]; found {
+				apiResourceImport.Annotations[apiextensionsv1.KubeAPIApprovedAnnotation] = value
+			}
+
+			logger.Info("creating APIResourceImport")
+			if _, err := i.kcpClient.ApiresourceV1alpha1().APIResourceImports().Create(ctx, apiResourceImport, metav1.CreateOptions{}); err != nil {
+				logger.Error(err, "error creating APIResourceImport")
+				continue
+			}
+		}
+		gvrsToSync[gvr.String()] = gvr
+	}
+
+	gvrsToRemove := sets.StringKeySet(i.SyncedGVRs).Difference(sets.StringKeySet(gvrsToSync))
+	for _, gvrToRemove := range gvrsToRemove.UnsortedList() {
+		gvr := i.SyncedGVRs[gvrToRemove]
+		objs, err := i.apiresourceImportIndexer.ByIndex(
+			GVRForLocationIndexName,
+			GetGVRForLocationIndexKey(i.syncTargetName, gvr),
+		)
+		logger := logger.WithValues(
+			"group", gvr.Group,
+			"version", gvr.Version,
+			"resource", gvr.Resource,
+		)
+
+		if err != nil {
+			logger.Error(err, "error pulling CRDs")
+			continue
+		}
+		if len(objs) > 1 {
+			logger.Error(fmt.Errorf("there should be only one APIResourceImport of GVR but there was %d", len(objs)), "err deleting APIResourceImport")
+			continue
+		}
+		if len(objs) == 1 {
+			apiResourceImportToRemove := objs[0].(*apiresourcev1alpha1.APIResourceImport)
+			logger = logger.WithValues("apiResourceImport", apiResourceImportToRemove.Name)
+			logger.Info("deleting APIResourceImport")
+			err := i.kcpClient.ApiresourceV1alpha1().APIResourceImports().Delete(ctx, apiResourceImportToRemove.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error(err, "error deleting APIResourceImport")
+				continue
+			}
+		}
+	}
+}

--- a/pkg/syncer/controllermanager/controllermanager.go
+++ b/pkg/syncer/controllermanager/controllermanager.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllermanager
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+const (
+	ControllerNamePrefix = "syncer-controller-manager-"
+)
+
+// InformerSource is a dynamic source of informers per GVR,
+// which notifies when informers are added or removed for some GVR.
+// It is implemented by the DynamicSharedInformerFactory (in fact by
+// both the scoped or cluster-aware variants).
+type InformerSource struct {
+	// Subscribe registers for informer change notifications, returning a channel to which change notifications are sent.
+	// The id argument is the identifier of the subscriber, since there might be several subscribers subscribing
+	// to receive events from this InformerSource.
+	Subscribe func(id string) <-chan struct{}
+
+	// Informers returns a map of per-resource-type SharedIndexInformers for all types that are
+	// known by this informer source, and that are synced.
+	//
+	// It also returns the list of informers that are known by this informer source, but sill not synced.
+	Informers func() (informers map[schema.GroupVersionResource]cache.SharedIndexInformer, notSynced []schema.GroupVersionResource)
+}
+
+// ManagedController defines a controller that should be managed by a ControllerManager,
+// to be started when the required GVRs are supported, and stopped when the required GVRs
+// are not supported anymore.
+type ManagedController struct {
+	RequiredGVRs []schema.GroupVersionResource
+	Create       CreateControllerFunc
+}
+
+type StartControllerFunc func(ctx context.Context)
+type CreateControllerFunc func(ctx context.Context) (StartControllerFunc, error)
+
+// NewControllerManager creates a new ControllerManager which will manage (create/start/stop) GVR-specific controllers according to informers
+// available in the provided InformerSource.
+func NewControllerManager(ctx context.Context, suffix string, informerSource InformerSource, controllers map[string]ManagedController) *ControllerManager {
+	controllerManager := ControllerManager{
+		name:               ControllerNamePrefix + suffix,
+		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerNamePrefix+suffix),
+		informerSource:     informerSource,
+		managedControllers: controllers,
+		startedControllers: map[string]context.CancelFunc{},
+	}
+
+	apisChanged := informerSource.Subscribe(controllerManager.name)
+
+	logger := klog.FromContext(ctx)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-apisChanged:
+				logger.V(4).Info("got API change notification")
+				controllerManager.queue.Add("resync") // this queue only ever has one key in it, as long as it's constant we are OK
+			}
+		}
+	}()
+
+	return &controllerManager
+}
+
+// ControllerManager is a component that manages (create/start/stop) GVR-specific controllers according to available GVRs.
+// It reacts to the changes of supported GVRs in a DiscoveringDynamicSharedInformerFactory
+// (the GVRs for which an informer has been automatically created, started and synced),
+// and starts / stops registered GVRs-specific controllers according to the GVRs they depend on.
+//
+// For example this allows starting PVC / PV controllers only when PVC / PV resources are exposed by the Syncer and UpSyncer
+// virtual workspaces, and Informers for them have been started and synced by the corresponding ddsif.
+type ControllerManager struct {
+	name               string
+	queue              workqueue.RateLimitingInterface
+	informerSource     InformerSource
+	managedControllers map[string]ManagedController
+	startedControllers map[string]context.CancelFunc
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *ControllerManager) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), c.name)
+	logger.Info("Starting controller manager")
+	defer logger.Info("Shutting down controller manager")
+
+	go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	<-ctx.Done()
+}
+
+func (c *ControllerManager) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *ControllerManager) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	c.process(ctx)
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *ControllerManager) process(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	controllersToStart := map[string]CreateControllerFunc{}
+	syncedInformers, notSynced := c.informerSource.Informers()
+controllerLoop:
+	for controllerName, managedController := range c.managedControllers {
+		requiredGVRs := managedController.RequiredGVRs
+		for _, gvr := range requiredGVRs {
+			informer := syncedInformers[gvr]
+			if informer == nil {
+				if shared.ContainsGVR(notSynced, gvr) {
+					logger.V(2).Info("waiting for the informer to be synced before starting controller", "gvr", gvr, "controller", controllerName)
+					c.queue.AddAfter("resync", time.Second)
+					continue controllerLoop
+				}
+				// The informer doesn't even exist for this GVR.
+				// Let's ignore this controller for now: one of the required GVRs has no informer started
+				// (because it has not been found on the SyncTarget in the supported resources to sync).
+				// If this required GVR is supported later on, the updateControllers() method will be called
+				// again after an API change notification comes through the informerSource.
+				continue controllerLoop
+			}
+		}
+		controllersToStart[controllerName] = managedController.Create
+	}
+
+	// Remove obsolete controllers that don't have their required GVRs anymore
+	for controllerName, cancelFunc := range c.startedControllers {
+		if _, ok := controllersToStart[controllerName]; ok {
+			// The controller is still expected => don't remove it
+			continue
+		}
+		// The controller should not be running
+		// Stop it and remove it from the list of started controllers
+		cancelFunc()
+		delete(c.startedControllers, controllerName)
+	}
+
+	// Create and start missing controllers that have their required GVRs synced
+	for controllerName, create := range controllersToStart {
+		if _, ok := c.startedControllers[controllerName]; ok {
+			// The controller is already started
+			continue
+		}
+
+		// Create the controller
+		start, err := create(ctx)
+		if err != nil {
+			logger.Error(err, "failed creating controller", "controller", controllerName)
+			continue
+		}
+
+		// Start the controller
+		controllerContext, cancelFunc := context.WithCancel(ctx)
+		go start(controllerContext)
+		c.startedControllers[controllerName] = cancelFunc
+	}
+}

--- a/pkg/syncer/endpoints/endpoint_downstream_controller.go
+++ b/pkg/syncer/endpoints/endpoint_downstream_controller.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+const (
+	ControllerName = "syncer-endpoint-controller"
+)
+
+var (
+	endpointsGVR  = corev1.SchemeGroupVersion.WithResource("endpoints")
+	servicesGVR   = corev1.SchemeGroupVersion.WithResource("services")
+	namespacesGVR = corev1.SchemeGroupVersion.WithResource("namespaces")
+)
+
+// NewEndpointController returns new controller which would annotate Endpoints related to synced Services, so that those Endpoints
+// would be upsynced by the UpSyncer to the upstream KCP workspace.
+// This would be useful to enable components such as a KNative controller (running against the KCP workspace) to see the Endpoint,
+// and confirm that the related Service is effective.
+func NewEndpointController(
+	downstreamClient dynamic.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	syncTargetClusterName logicalcluster.Name,
+	syncTargetName string,
+	syncTargetUID types.UID,
+) (*controller, error) {
+	c := &controller{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName),
+
+		syncTargetClusterName: syncTargetClusterName,
+		syncTargetName:        syncTargetName,
+		syncTargetUID:         syncTargetUID,
+		syncTargetKey:         workloadv1alpha1.ToSyncTargetKey(syncTargetClusterName, syncTargetName),
+
+		getDownstreamResource: func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			object, err := informer.Lister().ByNamespace(namespace).Get(name)
+			if err != nil {
+				return nil, err
+			}
+			unstr, ok := object.(*unstructured.Unstructured)
+			if !ok {
+				return nil, fmt.Errorf("object type should be *unstructured.Unstructured but was %t", object)
+			}
+			return unstr, nil
+		},
+		getDownstreamNamespace: func(name string) (*unstructured.Unstructured, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[namespacesGVR]
+			if !ok {
+				if shared.ContainsGVR(notSynced, namespacesGVR) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", namespacesGVR)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", namespacesGVR)
+			}
+			object, err := informer.Lister().Get(name)
+			if err != nil {
+				return nil, err
+			}
+			unstr, ok := object.(*unstructured.Unstructured)
+			if !ok {
+				return nil, fmt.Errorf("object type should be *unstructured.Unstructured but was %t", object)
+			}
+			return unstr, nil
+		},
+		patchEndpoint: func(ctx context.Context, namespace, name string, pt types.PatchType, data []byte) error {
+			_, err := downstreamClient.Resource(endpointsGVR).Namespace(namespace).Patch(ctx, name, pt, data, metav1.PatchOptions{})
+			return err
+		},
+	}
+
+	informers, _ := ddsifForDownstream.Informers()
+	endpointsInformer, ok := informers[endpointsGVR]
+	if !ok {
+		return nil, errors.New("endpoints informer should be available")
+	}
+
+	_, _ = endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueEndpoints(obj)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			c.enqueueEndpoints(new)
+		},
+	})
+
+	servicesInformer, ok := informers[servicesGVR]
+	if !ok {
+		return nil, errors.New("endpoints informer should be available")
+	}
+
+	_, _ = servicesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, new interface{}) {
+			c.enqueueService(new)
+		},
+	})
+
+	return c, nil
+}
+
+type controller struct {
+	queue workqueue.RateLimitingInterface
+
+	syncTargetClusterName logicalcluster.Name
+	syncTargetName        string
+	syncTargetUID         types.UID
+	syncTargetKey         string
+
+	getDownstreamResource  func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
+	getDownstreamNamespace func(name string) (*unstructured.Unstructured, error)
+	patchEndpoint          func(ctx context.Context, namespace, name string, pt types.PatchType, data []byte) error
+}
+
+func (c *controller) enqueueEndpoints(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+	logger.V(2).Info("queueing")
+	c.queue.Add(key)
+}
+
+func (c *controller) enqueueService(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "error when queueing from the related service")
+	}
+
+	_, err = c.getDownstreamResource(endpointsGVR, namespace, name)
+	if kerrors.IsNotFound(err) {
+		// no related Endpoints resource => nothing to do
+		return
+	}
+	if err != nil {
+		logger.Error(err, "error when queueing from the related service")
+	}
+
+	logger.V(2).Info("queueing from service")
+	c.queue.Add(key)
+}
+
+// Start starts N worker processes processing work items.
+func (c *controller) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer func() {
+		logger.Info("Shutting down controller")
+	}()
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+
+	qk := key.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), qk)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing", qk)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, qk); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}

--- a/pkg/syncer/endpoints/endpoint_downstream_process.go
+++ b/pkg/syncer/endpoints/endpoint_downstream_process.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+func (c *controller) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	logger = logger.WithValues(logging.NamespaceKey, namespace, logging.NameKey, name)
+
+	namespaceObj, err := c.getDownstreamNamespace(namespace)
+	if kerrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	locator, ok, err := shared.LocatorFromAnnotations(namespaceObj.GetAnnotations())
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	if string(locator.SyncTarget.UID) != string(c.syncTargetUID) ||
+		locator.SyncTarget.Name != c.syncTargetName ||
+		locator.SyncTarget.ClusterName != c.syncTargetClusterName.String() {
+		return nil
+	}
+
+	endpoints, err := c.getDownstreamResource(endpointsGVR, namespace, name)
+	if kerrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if endpoints.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+		// Endpoints resource already labelled for upsyncing. Nothing more to do.
+		return nil
+	}
+
+	service, err := c.getDownstreamResource(servicesGVR, namespace, name)
+	if kerrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Service has owner refs ? => it was certainly created downstream from an already synced higher level resource (KNative ?).
+	// Resources synced by the Syncer do not have owner references.
+	if len(service.GetOwnerReferences()) > 0 {
+		logger.V(3).Info("ignoring endpoint since it has an owner reference")
+		return nil
+	}
+
+	derivedResourcesToUpsync := strings.Split(service.GetAnnotations()[workloadv1alpha1.ExperimentalUpsyncDerivedResourcesAnnotationKey], ",")
+	if len(derivedResourcesToUpsync) == 0 ||
+		!sets.New[string](derivedResourcesToUpsync...).Has(endpointsGVR.GroupResource().String()) {
+		logger.V(3).Info("ignoring endpoint since it is not mentioned in the service 'workload.kcp.io/upsync-derived-resources' annotation")
+		return nil
+	}
+
+	logger.V(1).Info("adding the upsync label on endpoint")
+	err = c.patchEndpoint(ctx, namespace, name, types.StrategicMergePatchType, []byte(
+		`{"metadata": {"labels": {"`+
+			workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetKey+`":"`+string(workloadv1alpha1.ResourceStateUpsync)+
+			`"}}}`))
+	if kerrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/syncer/endpoints/endpoint_downstream_process_test.go
+++ b/pkg/syncer/endpoints/endpoint_downstream_process_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+}
+
+func TestEndpointsControllerProcess(t *testing.T) {
+	defaultSyncTargetLocator := shared.SyncTargetLocator{
+		ClusterName: "root:org:ws",
+		Name:        "us-west1",
+		UID:         types.UID("syncTargetUID"),
+	}
+
+	tests := map[string]struct {
+		endpointName string
+
+		syncTargetLocator *shared.SyncTargetLocator
+
+		downstreamNamespace *corev1.Namespace
+		namespaceGetError   error
+
+		downstreamEndpoints *corev1.Endpoints
+		endpointsGetError   error
+
+		downstreamService *corev1.Service
+		serviceGetError   error
+
+		expectedError     string
+		expectedPatch     string
+		expectedPatchType types.PatchType
+	}{
+		"Label the endpoints when service is there and annotated": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService: service("httpecho").WithNamespace("downstream-ns").WithAnnotations(map[string]string{
+				"experimental.workload.kcp.io/upsync-derived-resources": "pods,endpoints",
+			}).Object(),
+			expectedPatch:     `{"metadata": {"labels": {"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g":"Upsync"}}}`,
+			expectedPatchType: types.StrategicMergePatchType,
+		},
+		"Don't label the endpoints when service is there but not annotated correctly": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService: service("httpecho").WithNamespace("downstream-ns").WithAnnotations(map[string]string{
+				"workload.kcp.io/upsync-derived-resources": "pods",
+			}).Object(),
+		},
+		"Don't label the endpoints when service is there but not annotated": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Don't label the endpoints when namespace resource is not found": {
+			endpointName:        "httpecho",
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Error when namespace retrieval fails": {
+			endpointName:        "httpecho",
+			namespaceGetError:   errors.New("error"),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+			expectedError:       "error",
+		},
+		"Don't label the endpoints when namespace has no locator": {
+			endpointName:        "httpecho",
+			downstreamNamespace: namespace("downstream-ns").Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Error on wrong namespace locator": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithAnnotations(map[string]string{
+				"kcp.io/namespace-locator": "invalid json content",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+			expectedError:       "invalid character 'i' looking for beginning of value",
+		},
+		"Don't label the endpoints when namespace locator syncTarget cluster name doesn't match": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{
+				SyncTarget: shared.SyncTargetLocator{
+					ClusterName: "another Cluster",
+					Name:        defaultSyncTargetLocator.Name,
+					UID:         defaultSyncTargetLocator.UID,
+				},
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Don't label the endpoints when namespace locator syncTarget name doesn't match": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{
+				SyncTarget: shared.SyncTargetLocator{
+					ClusterName: defaultSyncTargetLocator.ClusterName,
+					Name:        "anotherName",
+					UID:         defaultSyncTargetLocator.UID,
+				},
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Don't label the endpoints when namespace locator syncTarget UID doesn't match": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{
+				SyncTarget: shared.SyncTargetLocator{
+					ClusterName: defaultSyncTargetLocator.ClusterName,
+					Name:        defaultSyncTargetLocator.Name,
+					UID:         types.UID("anotherUID"),
+				},
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Don't label the endpoints when endpoints resource is not found": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamService: service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Error when endpoints retrieval fails": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			endpointsGetError: errors.New("error"),
+			downstreamService: service("httpecho").WithNamespace("downstream-ns").Object(),
+			expectedError:     "error",
+		},
+		"Don't label the endpoints when endpoints is labelled for upsync already": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").WithLabels(map[string]string{
+				"state.workload.kcp.io/" + workloadv1alpha1.ToSyncTargetKey(logicalcluster.Name(defaultSyncTargetLocator.ClusterName), defaultSyncTargetLocator.Name): "Upsync",
+			}).Object(),
+			downstreamService: service("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Don't label the endpoints when service resource is not found": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+		},
+		"Error when service retrieval fails": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			serviceGetError:     errors.New("error"),
+			expectedError:       "error",
+		},
+		"Don't label the endpoints when service has an owner refs": {
+			endpointName: "httpecho",
+			downstreamNamespace: namespace("downstream-ns").WithLocator(t, shared.NamespaceLocator{SyncTarget: defaultSyncTargetLocator,
+				ClusterName: logicalcluster.Name("root:org:ws"),
+				Namespace:   "ns",
+			}).Object(),
+			downstreamEndpoints: endpoints("httpecho").WithNamespace("downstream-ns").Object(),
+			downstreamService:   service("httpecho").WithNamespace("downstream-ns").WithOwnerRef().Object(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if tc.syncTargetLocator == nil {
+				tc.syncTargetLocator = &defaultSyncTargetLocator
+			}
+
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(logicalcluster.Name(tc.syncTargetLocator.ClusterName), tc.syncTargetLocator.Name)
+
+			actualPatch := ""
+			var actualPatchType types.PatchType
+			controller := controller{
+				queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+
+				syncTargetName:        tc.syncTargetLocator.Name,
+				syncTargetClusterName: logicalcluster.Name(tc.syncTargetLocator.ClusterName),
+				syncTargetUID:         tc.syncTargetLocator.UID,
+				syncTargetKey:         syncTargetKey,
+
+				getDownstreamResource: func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+					var obj runtime.Object
+					switch gvr {
+					case endpointsGVR:
+						if tc.endpointsGetError != nil {
+							return nil, tc.endpointsGetError
+						}
+						if tc.downstreamEndpoints == nil {
+							return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
+						}
+						obj = tc.downstreamEndpoints
+					case servicesGVR:
+						if tc.serviceGetError != nil {
+							return nil, tc.serviceGetError
+						}
+						if tc.downstreamService == nil {
+							return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
+						}
+						obj = tc.downstreamService
+					}
+					var unstr unstructured.Unstructured
+					err := scheme.Convert(obj, &unstr, nil)
+					require.NoError(t, err)
+					return &unstr, nil
+				},
+				getDownstreamNamespace: func(name string) (*unstructured.Unstructured, error) {
+					if tc.namespaceGetError != nil {
+						return nil, tc.namespaceGetError
+					}
+					if tc.downstreamNamespace == nil {
+						return nil, apierrors.NewNotFound(namespacesGVR.GroupResource(), name)
+					}
+					var unstr unstructured.Unstructured
+					err := scheme.Convert(tc.downstreamNamespace, &unstr, nil)
+					require.NoError(t, err)
+					return &unstr, nil
+				},
+				patchEndpoint: func(ctx context.Context, namespace, name string, pt types.PatchType, data []byte) error {
+					actualPatch = string(data)
+					actualPatchType = pt
+					return nil
+				},
+			}
+
+			namespaceName := ""
+			if tc.downstreamNamespace != nil {
+				namespaceName = tc.downstreamNamespace.Name
+			}
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(&metav1.ObjectMeta{
+				Name:      tc.endpointName,
+				Namespace: namespaceName,
+			})
+			require.NoError(t, err)
+			err = controller.process(ctx, key)
+
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedPatch, actualPatch)
+			require.Equal(t, tc.expectedPatchType, actualPatchType)
+		})
+	}
+}
+
+type resourceBuilder[Type metav1.Object] struct {
+	obj Type
+}
+
+func (r *resourceBuilder[Type]) Object() Type {
+	return r.obj
+}
+
+func (r *resourceBuilder[Type]) WithNamespace(namespace string) *resourceBuilder[Type] {
+	r.obj.SetNamespace(namespace)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithOwnerRef() *resourceBuilder[Type] {
+	r.obj.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			Name: "name",
+		},
+	})
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithLocator(t *testing.T, locator shared.NamespaceLocator) *resourceBuilder[Type] {
+	locatorJSON, err := json.Marshal(locator)
+	require.NoError(t, err)
+	r.WithAnnotations(map[string]string{
+		shared.NamespaceLocatorAnnotation: string(locatorJSON),
+	})
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithAnnotations(additionalAnnotations map[string]string) *resourceBuilder[Type] {
+	annotations := r.obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for k, v := range additionalAnnotations {
+		annotations[k] = v
+	}
+
+	r.obj.SetAnnotations(annotations)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithLabels(additionalLabels map[string]string) *resourceBuilder[Type] {
+	labels := r.obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+
+	r.obj.SetLabels(labels)
+	return r
+}
+
+func newResourceBuilder[Type metav1.Object](obj Type, name string) *resourceBuilder[Type] {
+	obj.SetName(name)
+	return &resourceBuilder[Type]{obj}
+}
+
+func namespace(name string) *resourceBuilder[*corev1.Namespace] {
+	return newResourceBuilder(&corev1.Namespace{}, name)
+}
+
+func endpoints(name string) *resourceBuilder[*corev1.Endpoints] {
+	return newResourceBuilder(&corev1.Endpoints{}, name)
+}
+
+func service(name string) *resourceBuilder[*corev1.Service] {
+	return newResourceBuilder(&corev1.Service{}, name)
+}

--- a/pkg/syncer/indexers/indexes.go
+++ b/pkg/syncer/indexers/indexes.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+const (
+	ByNamespaceLocatorIndexName = "syncer-spec-ByNamespaceLocator"
+)
+
+// indexByNamespaceLocator is a cache.IndexFunc that indexes namespaces by the namespaceLocator annotation.
+func IndexByNamespaceLocator(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+	if loc, found, err := shared.LocatorFromAnnotations(metaObj.GetAnnotations()); err != nil {
+		return []string{}, fmt.Errorf("failed to get locator from annotations: %w", err)
+	} else if !found {
+		return []string{}, nil
+	} else {
+		bs, err := json.Marshal(loc)
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to marshal locator %#v: %w", loc, err)
+		}
+		return []string{string(bs)}, nil
+	}
+}

--- a/pkg/syncer/module/defaults.go
+++ b/pkg/syncer/module/defaults.go
@@ -1,0 +1,48 @@
+package module
+
+import (
+	"context"
+	"sync/atomic"
+
+	"k8s.io/klog/v2"
+)
+
+// DefaultLogger implements Logger using klog.
+type DefaultLogger struct{}
+
+func (DefaultLogger) Info(msg string, keysAndValues ...interface{}) {
+	klog.InfoS(msg, keysAndValues...)
+}
+
+func (DefaultLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	klog.ErrorS(err, msg, keysAndValues...)
+}
+
+// DefaultMetricsCollector provides basic counters for conflicts and errors.
+type DefaultMetricsCollector struct {
+	conflict atomic.Int64
+	errCount atomic.Int64
+}
+
+func (m *DefaultMetricsCollector) IncConflict() { m.conflict.Add(1) }
+func (m *DefaultMetricsCollector) IncError()    { m.errCount.Add(1) }
+
+// NopResourceSyncer is a placeholder ResourceSyncer used until concrete
+// implementations are wired in.
+type NopResourceSyncer struct{}
+
+func (NopResourceSyncer) Start(ctx context.Context) error { return nil }
+
+// NopConflictResolver simply returns the provided error.
+type NopConflictResolver struct{}
+
+func (NopConflictResolver) Resolve(ctx context.Context, err error) error { return err }
+
+// NopErrorHandler logs the error via the provided logger if any.
+type NopErrorHandler struct{ Logger }
+
+func (h NopErrorHandler) Handle(ctx context.Context, err error) {
+	if err != nil && h.Logger != nil {
+		h.Logger.Error(err, "syncer error")
+	}
+}

--- a/pkg/syncer/module/interfaces.go
+++ b/pkg/syncer/module/interfaces.go
@@ -1,0 +1,30 @@
+package module
+
+import "context"
+
+// ResourceSyncer defines an interface for synchronizing resources between KCP and workload clusters.
+type ResourceSyncer interface {
+	Start(ctx context.Context) error
+}
+
+// ConflictResolver defines an interface for resolving conflicts encountered during synchronization.
+type ConflictResolver interface {
+	Resolve(ctx context.Context, err error) error
+}
+
+// ErrorHandler defines an interface for handling non-conflict errors during synchronization.
+type ErrorHandler interface {
+	Handle(ctx context.Context, err error)
+}
+
+// MetricsCollector defines an interface for collecting synchronization metrics.
+type MetricsCollector interface {
+	IncConflict()
+	IncError()
+}
+
+// Logger abstracts logging functionality for synchronization activities.
+type Logger interface {
+	Info(msg string, keysAndValues ...interface{})
+	Error(err error, msg string, keysAndValues ...interface{})
+}

--- a/pkg/syncer/module/modules.go
+++ b/pkg/syncer/module/modules.go
@@ -1,0 +1,29 @@
+package module
+
+// Modules groups implementations of the various syncer modules.
+type Modules struct {
+	ResourceSyncer   ResourceSyncer
+	ConflictResolver ConflictResolver
+	ErrorHandler     ErrorHandler
+	MetricsCollector MetricsCollector
+	Logger           Logger
+}
+
+// ApplyDefaults populates nil modules with default implementations.
+func (m *Modules) ApplyDefaults() {
+	if m.ResourceSyncer == nil {
+		m.ResourceSyncer = NopResourceSyncer{}
+	}
+	if m.ConflictResolver == nil {
+		m.ConflictResolver = NopConflictResolver{}
+	}
+	if m.ErrorHandler == nil {
+		m.ErrorHandler = NopErrorHandler{Logger: m.Logger}
+	}
+	if m.MetricsCollector == nil {
+		m.MetricsCollector = &DefaultMetricsCollector{}
+	}
+	if m.Logger == nil {
+		m.Logger = DefaultLogger{}
+	}
+}

--- a/pkg/syncer/namespace/namespace_downstream_controller.go
+++ b/pkg/syncer/namespace/namespace_downstream_controller.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+)
+
+const (
+	controllerNameRoot       = "kcp-workload-syncer-namespace"
+	downstreamControllerName = controllerNameRoot + "-downstream"
+)
+
+type DownstreamController struct {
+	queue        workqueue.RateLimitingInterface
+	delayedQueue workqueue.RateLimitingInterface
+
+	lock                sync.Mutex
+	toDeleteMap         map[string]time.Time
+	namespaceCleanDelay time.Duration
+
+	deleteDownstreamNamespace func(ctx context.Context, namespace string) error
+	upstreamNamespaceExists   func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error)
+	getDownstreamNamespace    func(name string) (runtime.Object, error)
+	listDownstreamNamespaces  func() ([]runtime.Object, error)
+	isDowntreamNamespaceEmpty func(ctx context.Context, namespace string) (bool, error)
+	createConfigMap           func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	updateConfigMap           func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+
+	syncTargetName        string
+	syncTargetClusterName logicalcluster.Name
+	syncTargetUID         types.UID
+	syncTargetKey         string
+	dnsNamespace          string
+}
+
+func NewDownstreamController(
+	syncerLogger logr.Logger,
+	syncTargetWorkspace logicalcluster.Name,
+	syncTargetName, syncTargetKey string,
+	syncTargetUID types.UID,
+	downstreamConfig *rest.Config,
+	downstreamClient dynamic.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	getShardAccess synctarget.GetShardAccessFunc,
+	dnsNamespace string,
+	namespaceCleanDelay time.Duration,
+) (*DownstreamController, error) {
+	namespaceGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	logger := logging.WithReconciler(syncerLogger, downstreamControllerName)
+	kubeClient := kubernetes.NewForConfigOrDie(downstreamConfig)
+
+	c := DownstreamController{
+		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), downstreamControllerName),
+		delayedQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), downstreamControllerName),
+		toDeleteMap:  make(map[string]time.Time),
+		deleteDownstreamNamespace: func(ctx context.Context, namespace string) error {
+			return downstreamClient.Resource(namespaceGVR).Delete(ctx, namespace, metav1.DeleteOptions{})
+		},
+		upstreamNamespaceExists: func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error) {
+			shardAccess, ok, err := getShardAccess(clusterName)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				return false, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+
+			informer, err := shardAccess.SyncerDDSIF.ForResource(namespaceGVR)
+			if err != nil {
+				return false, err
+			}
+
+			_, err = informer.Lister().ByCluster(clusterName).Get(upstreamNamespaceName)
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		},
+		getDownstreamNamespace: func(downstreamNamespaceName string) (runtime.Object, error) {
+			informer, err := ddsifForDownstream.ForResource(namespaceGVR)
+			if err != nil {
+				return nil, err
+			}
+			return informer.Lister().Get(downstreamNamespaceName)
+		},
+		listDownstreamNamespaces: func() ([]runtime.Object, error) {
+			informer, err := ddsifForDownstream.ForResource(namespaceGVR)
+			if err != nil {
+				return nil, err
+			}
+			return informer.Lister().List(labels.Everything())
+		},
+		isDowntreamNamespaceEmpty: func(ctx context.Context, namespace string) (bool, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			if len(notSynced) > 0 {
+				return false, fmt.Errorf("some informers are still not synced in the downstream informer factory")
+			}
+
+			for gvr, informer := range informers {
+				// Skip namespaces.
+				if gvr == namespaceGVR {
+					continue
+				}
+				list, err := informer.Lister().ByNamespace(namespace).List(labels.Everything())
+				if err != nil {
+					return false, err
+				}
+				if len(list) > 0 {
+					return false, nil
+				}
+			}
+			return true, nil
+		},
+		createConfigMap: func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			return kubeClient.CoreV1().ConfigMaps(configMap.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		},
+		updateConfigMap: func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			return kubeClient.CoreV1().ConfigMaps(configMap.Namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+		},
+
+		syncTargetName:        syncTargetName,
+		syncTargetClusterName: syncTargetWorkspace,
+		syncTargetUID:         syncTargetUID,
+		syncTargetKey:         syncTargetKey,
+		dnsNamespace:          dnsNamespace,
+
+		namespaceCleanDelay: namespaceCleanDelay,
+	}
+
+	logger.V(2).Info("Set up downstream namespace informer")
+
+	// Those handlers are for start/resync cases, in case a namespace deletion event is missed, these handlers
+	// will make sure that we cleanup the namespace in downstream after restart/resync.
+	ddsifForDownstream.AddEventHandler(ddsif.GVREventHandlerFuncs{
+		AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if gvr == namespaceGVR {
+				c.AddToQueue(obj, logger)
+			}
+		},
+		DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if gvr == namespaceGVR {
+				c.AddToQueue(obj, logger)
+			}
+		},
+	})
+	return &c, nil
+}
+
+func (c *DownstreamController) AddToQueue(obj interface{}, logger logr.Logger) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj) // note: this is *not* a cluster-aware key
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(2).Info("queueing namespace")
+	c.queue.Add(key)
+}
+
+// Start starts N worker processes processing work items.
+func (c *DownstreamController) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+	defer c.delayedQueue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), downstreamControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+		go wait.UntilWithContext(ctx, c.startDelayedWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *DownstreamController) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *DownstreamController) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	namespaceKey := key.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), namespaceKey)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, namespaceKey); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", downstreamControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}
+
+func (c *DownstreamController) isPlannedForCleaning(key string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, ok := c.toDeleteMap[key]
+	return ok
+}
+
+func (c *DownstreamController) CancelCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	delete(c.toDeleteMap, key)
+}
+
+func (c *DownstreamController) PlanCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	now := time.Now()
+	if plannedFor, planned := c.toDeleteMap[key]; !planned || now.After(plannedFor) {
+		c.toDeleteMap[key] = now.Add(c.namespaceCleanDelay)
+		c.delayedQueue.AddAfter(key, c.namespaceCleanDelay)
+	}
+}
+
+func (c *DownstreamController) startDelayedWorker(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithValues("queue", "delayed")
+	ctx = klog.NewContext(ctx, logger)
+	for c.processNextDelayedWorkItem(ctx) {
+	}
+}
+
+func (c *DownstreamController) processNextDelayedWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.delayedQueue.Get()
+	if quit {
+		return false
+	}
+	namespaceKey := key.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), namespaceKey)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.delayedQueue.Done(key)
+
+	if err := c.processDelayed(ctx, namespaceKey); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", downstreamControllerName, key, err))
+		c.delayedQueue.AddRateLimited(key)
+		return true
+	}
+	c.delayedQueue.Forget(key)
+	return true
+}
+
+func (c *DownstreamController) processDelayed(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	if !c.isPlannedForCleaning(key) {
+		logger.V(2).Info("Namespace is not marked for deletion check anymore, skipping")
+		return nil
+	}
+
+	empty, err := c.isDowntreamNamespaceEmpty(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to check if downstream namespace is empty: %w", err)
+	}
+	if !empty {
+		logger.V(2).Info("Namespace is not empty, skip cleaning now but keep it as a candidate for future cleaning")
+		return nil
+	}
+
+	err = c.deleteDownstreamNamespace(ctx, key)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if apierrors.IsNotFound(err) {
+		logger.V(2).Info("Namespace is not found, perhaps it was already deleted")
+	}
+	c.CancelCleaning(key)
+	return nil
+}

--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+func (c *DownstreamController) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	_, namespaceName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "invalid key")
+		return nil
+	}
+
+	logger = logger.WithValues(DownstreamNamespace, namespaceName)
+
+	downstreamNamespaceObj, err := c.getDownstreamNamespace(namespaceName)
+	if apierrors.IsNotFound(err) {
+		logger.V(4).Info("downstream namespace not found, ignoring key")
+		return nil
+	} else if err != nil {
+		logger.Error(err, "failed to get downstream namespace")
+		return nil
+	}
+
+	downstreamNamespace := downstreamNamespaceObj.(*unstructured.Unstructured)
+	logger = logging.WithObject(logger, downstreamNamespace)
+
+	namespaceLocatorJSON := downstreamNamespace.GetAnnotations()[shared.NamespaceLocatorAnnotation]
+	if namespaceLocatorJSON == "" {
+		logger.Error(nil, "downstream namespace has no namespaceLocator annotation")
+		return nil
+	}
+
+	nsLocator := shared.NamespaceLocator{}
+	if err := json.Unmarshal([]byte(namespaceLocatorJSON), &nsLocator); err != nil {
+		logger.Error(err, "failed to unmarshal namespace locator", "namespaceLocator", namespaceLocatorJSON)
+		return nil
+	}
+
+	// Check if the nsLocator SyncTarget UID is the same as ours. If not, we should ignore this namespace as it could be
+	// managed by different syncer.
+	if nsLocator.SyncTarget.UID != c.syncTargetUID {
+		logger.V(4).Info("downstream namespace is not handled by this sync target, ignoring")
+		return nil
+	}
+
+	// Always refresh the DNS ConfigMap (even when the namespace has been deleted or is being deleted)
+	err = c.updateDNSConfigMap(ctx, nsLocator.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	if !downstreamNamespace.GetDeletionTimestamp().IsZero() {
+		logger.V(4).Info("downstream namespace is being deleted, ignoring key")
+		return nil
+	}
+
+	logger = logger.WithValues(logging.WorkspaceKey, nsLocator.ClusterName, logging.NamespaceKey, nsLocator.Namespace)
+	exists, err := c.upstreamNamespaceExists(nsLocator.ClusterName, nsLocator.Namespace)
+	if err != nil {
+		logger.Error(err, "failed to check if upstream namespace exists")
+		return nil
+	}
+	if !exists {
+		logger.Info("adding the downstream namespace to the delayed deletion queue because the upstream namespace doesn't exist")
+		c.PlanCleaning(key)
+		return nil
+	}
+	// The namespace exists upstream, so we can remove it from the delayed delete queue
+	c.CancelCleaning(key)
+	// The upstream namespace still exists, nothing to do.
+	return nil
+}
+
+func (c *DownstreamController) updateDNSConfigMap(ctx context.Context, clusterName logicalcluster.Name) error {
+	logger := klog.FromContext(ctx)
+	logger.WithName("dns")
+	logger.Info("refreshing logical to physical namespace mapping table")
+
+	// Reconstruct ConfigMap from scratch because:
+	// - it's a sound approach
+	// - it's low overhead considering operations on namespaces are relatively rare.
+
+	namespaces, err := c.listDownstreamNamespaces()
+	if err != nil {
+		logger.Error(err, "failed to list downstream namespaces")
+		return err // retry
+	}
+
+	data := make(map[string]string)
+	for _, obj := range namespaces {
+		namespace := obj.(*unstructured.Unstructured)
+		annotations := namespace.GetAnnotations()
+		if annotations == nil {
+			// skip
+			continue
+		}
+
+		locator, found, err := shared.LocatorFromAnnotations(annotations)
+		if err != nil {
+			// Corrupted ns locator annotation value
+			logger.Error(err, "invalid namespace locator", "name", namespace.GetName())
+			continue
+		}
+
+		if !found {
+			continue
+		}
+
+		// Only include namespaces in the same workspace
+		if locator.ClusterName == clusterName {
+			data[locator.Namespace] = namespace.GetName()
+		}
+	}
+
+	configMapName := shared.GetDNSID(clusterName, c.syncTargetUID, c.syncTargetName)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: c.dnsNamespace,
+		},
+		Data: data,
+	}
+
+	// TODO(LV): consider comparing the new ConfigMap with the cached one to avoid a rest api call.
+
+	_, err = c.updateConfigMap(ctx, cm)
+	if apierrors.IsNotFound(err) {
+		_, err = c.createConfigMap(ctx, cm)
+		if err == nil {
+			return nil
+		}
+	}
+	if err != nil {
+		logger.Error(err, "failed to create or update ConfigMap (retrying)", "name", configMapName, "namespace", c.dnsNamespace)
+		return err // retry
+	}
+	return nil
+}

--- a/pkg/syncer/namespace/namespace_downstream_process_test.go
+++ b/pkg/syncer/namespace/namespace_downstream_process_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/sdk/client"
+)
+
+func TestSyncerNamespaceProcess(t *testing.T) {
+	tests := map[string]struct {
+		upstreamNamespaceExists bool
+		deletedNamespace        string
+		syncTargetUID           types.UID
+
+		upstreamNamespaceExistsError                    error
+		getDownstreamNamespaceError                     error
+		getDownstreamNamespaceFromNamespaceLocatorError error
+
+		eventOrigin string // upstream or downstream
+	}{
+		"NamespaceSyncer removes downstream namespace when no matching upstream has been found, expect downstream namespace deletion": {
+			upstreamNamespaceExists: false,
+			deletedNamespace:        "kcp-33jbiactwhg0",
+			eventOrigin:             "downstream",
+		},
+		"NamespaceSyncer doesn't remove downstream namespace when nsLocator synctarget UID is different, expect no namespace deletion": {
+			upstreamNamespaceExists: false,
+			deletedNamespace:        "",
+			eventOrigin:             "downstream",
+			syncTargetUID:           "1234",
+		},
+		"NamespaceSyncer, downstream event, no deletion as there is a matching upstream namespace, expect no namespace deletion": {
+			upstreamNamespaceExists: true,
+			deletedNamespace:        "",
+			eventOrigin:             "downstream",
+		},
+		"NamespaceSyncer, downstream event, error trying to get the upstream namespace, expect no namespace deletion": {
+			upstreamNamespaceExistsError: errors.New("error"),
+			deletedNamespace:             "",
+			eventOrigin:                  "downstream",
+		},
+		"NamespaceSyncer, downstream event, error trying to get the downstream namespace, expect no namespace deletion": {
+			getDownstreamNamespaceError: errors.New("error"),
+			deletedNamespace:            "",
+			eventOrigin:                 "downstream",
+		},
+		"NamespaceSyncer, downstream event, downstream namespace is not found, expect no namespace deletion": {
+			getDownstreamNamespaceError: apierrors.NewNotFound(schema.GroupResource(metav1.GroupResource{Group: "", Resource: ""}), "not-found"),
+			deletedNamespace:            "",
+			eventOrigin:                 "downstream",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			downstreamNamespace := namespace(logicalcluster.NewPath(""), "kcp-33jbiactwhg0", map[string]string{
+				"internal.workload.kcp.io/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+			}, map[string]string{
+				"kcp.io/namespace-locator": `{"syncTarget":{"workspace":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
+			})
+			syncTargetClusterName := logicalcluster.Name("root:org:ws")
+			syncTargetName := "us-west1"
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(syncTargetClusterName, syncTargetName)
+			syncTargetUID := types.UID("syncTargetUID")
+			if tc.syncTargetUID != "" {
+				syncTargetUID = tc.syncTargetUID
+			}
+			nsController := DownstreamController{
+				toDeleteMap:  make(map[string]time.Time),
+				delayedQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), downstreamControllerName),
+				deleteDownstreamNamespace: func(ctx context.Context, downstreamNamespaceName string) error {
+					return nil
+				},
+				upstreamNamespaceExists: func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error) {
+					return tc.upstreamNamespaceExists, tc.upstreamNamespaceExistsError
+				},
+				getDownstreamNamespace: func(name string) (runtime.Object, error) {
+					nsJSON, _ := json.Marshal(downstreamNamespace)
+					unstructured := &unstructured.Unstructured{}
+					_ = json.Unmarshal(nsJSON, unstructured)
+					return unstructured, tc.getDownstreamNamespaceError
+				},
+				listDownstreamNamespaces: func() (ret []runtime.Object, err error) {
+					return []runtime.Object{}, nil
+				},
+				createConfigMap: func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+					return nil, nil
+				},
+				updateConfigMap: func(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+					return nil, nil
+				},
+				isDowntreamNamespaceEmpty: func(ctx context.Context, namespaceName string) (bool, error) {
+					return true, nil
+				},
+				syncTargetName:        syncTargetName,
+				syncTargetClusterName: syncTargetClusterName,
+				syncTargetUID:         syncTargetUID,
+				syncTargetKey:         syncTargetKey,
+				dnsNamespace:          "kcp-33jbiactwhg0",
+			}
+
+			var key string
+			if tc.eventOrigin == "downstream" {
+				key = downstreamNamespace.GetName()
+			} else if tc.eventOrigin == "upstream" {
+				key = client.ToClusterAwareKey(logicalcluster.NewPath("root:org:ws"), "test")
+			} else {
+				t.Fatalf("unexpected event origin: %s", tc.eventOrigin)
+			}
+
+			err := nsController.process(ctx, key)
+			require.NoError(t, err)
+
+			if tc.deletedNamespace != "" {
+				require.True(t, nsController.isPlannedForCleaning(tc.deletedNamespace))
+				require.Equal(t, len(nsController.toDeleteMap), 1)
+			} else {
+				require.Empty(t, len(nsController.toDeleteMap))
+			}
+		})
+	}
+}
+
+func namespace(clusterName logicalcluster.Path, name string, labels, annotations map[string]string) *corev1.Namespace {
+	if !clusterName.Empty() {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName.String()
+	}
+
+	return &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}

--- a/pkg/syncer/shared/cleaner.go
+++ b/pkg/syncer/shared/cleaner.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+// Cleaner is an interface for cleaning up resources.
+type Cleaner interface {
+	// PlanCleaning adds the key to the list of keys to be cleaned up.
+	// If the resource was already planned for cleaning the previous timestamp is kept.
+	PlanCleaning(key string)
+	// CancelCleaning removes the key from the list of keys to be cleaned up.
+	// If it wasn't planned for deletion, it does nothing.
+	CancelCleaning(key string)
+}

--- a/pkg/syncer/shared/finalizer.go
+++ b/pkg/syncer/shared/finalizer.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+const (
+	// SyncerFinalizerNamePrefix is the finalizer put onto resources by the syncer to claim ownership,
+	// *before* a downstream object is created. It is only removed when the downstream object is deleted.
+	SyncerFinalizerNamePrefix = "workload.kcp.io/syncer-"
+)
+
+func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamLister cache.GenericLister, upstreamClient dynamic.Interface, upstreamNamespace, syncTargetKey string, resourceName string) error {
+	logger := klog.FromContext(ctx)
+	upstreamObjFromLister, err := upstreamLister.ByNamespace(upstreamNamespace).Get(resourceName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	upstreamObj, ok := upstreamObjFromLister.(*unstructured.Unstructured)
+	if !ok {
+		logger.Info(fmt.Sprintf("Error: upstream resource expected to be *unstructured.Unstructured, got %T", upstreamObjFromLister))
+		return nil
+	}
+
+	// TODO(jmprusi): This check will need to be against "GetDeletionTimestamp()" when using the syncer virtual workspace.
+	if upstreamObj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+syncTargetKey] == "" {
+		// Do nothing: the object should not be deleted anymore for this location on the KCP side
+		return nil
+	}
+
+	upstreamObj = upstreamObj.DeepCopy()
+
+	// Remove the syncer finalizer.
+	currentFinalizers := upstreamObj.GetFinalizers()
+	desiredFinalizers := []string{}
+	for _, finalizer := range currentFinalizers {
+		if finalizer != SyncerFinalizerNamePrefix+syncTargetKey {
+			desiredFinalizers = append(desiredFinalizers, finalizer)
+		}
+	}
+	upstreamObj.SetFinalizers(desiredFinalizers)
+
+	//  TODO(jmprusi): This code block will be handled by the syncer virtual workspace, so we can remove it once
+	//                 the virtual workspace syncer is integrated
+	//  - Begin -
+	// Clean up the status annotation and the locationDeletionAnnotation.
+	annotations := upstreamObj.GetAnnotations()
+	delete(annotations, workloadv1alpha1.InternalClusterStatusAnnotationPrefix+syncTargetKey)
+	delete(annotations, workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+syncTargetKey)
+	upstreamObj.SetAnnotations(annotations)
+
+	// remove the cluster label.
+	upstreamLabels := upstreamObj.GetLabels()
+	delete(upstreamLabels, workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey)
+	upstreamObj.SetLabels(upstreamLabels)
+	// - End of block to be removed once the virtual workspace syncer is integrated -
+
+	if upstreamNamespace != "" {
+		_, err = upstreamClient.Resource(gvr).Namespace(upstreamObj.GetNamespace()).Update(ctx, upstreamObj, metav1.UpdateOptions{})
+	} else {
+		_, err = upstreamClient.Resource(gvr).Update(ctx, upstreamObj, metav1.UpdateOptions{})
+	}
+
+	if err != nil {
+		logger.Error(err, "Failed updating upstream resource after removing the syncer finalizer")
+		return err
+	}
+	logger.V(2).Info("Updated upstream resource to remove the syncer finalizer")
+	return nil
+}

--- a/pkg/syncer/shared/helpers.go
+++ b/pkg/syncer/shared/helpers.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/martinlindhe/base36"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+// SyncableClusterScopedResources holds a set of cluster-wide GVR that are allowed to be synced.
+var SyncableClusterScopedResources = sets.New[string](schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}.String())
+
+// DeprecatedGetAssignedSyncTarget returns one assigned sync target in Sync state. It will
+// likely lead to broken behaviour when there is one of those labels on a resource.
+//
+// Deprecated: use GetResourceState per cluster instead.
+func DeprecatedGetAssignedSyncTarget(labels map[string]string) string {
+	for k, v := range labels {
+		if strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) && v == string(workloadv1alpha1.ResourceStateSync) {
+			return strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix)
+		}
+	}
+	return ""
+}
+
+// GetUpstreamResourceName returns the name with which the resource is known upstream.
+func GetUpstreamResourceName(downstreamResourceGVR schema.GroupVersionResource, downstreamResourceName string) string {
+	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+
+	if downstreamResourceGVR == configMapGVR && downstreamResourceName == "kcp-root-ca.crt" {
+		return "kube-root-ca.crt"
+	}
+	if downstreamResourceGVR == secretGVR && strings.HasPrefix(downstreamResourceName, "kcp-default-token") {
+		return strings.TrimPrefix(downstreamResourceName, "kcp-")
+	}
+	return downstreamResourceName
+}
+
+// GetDNSID returns a unique ID for DNS object derived from the sync target name, its UID and workspace. It's
+// a valid DNS segment and can be used as namespace or object names.
+func GetDNSID(clusterName logicalcluster.Name, syncTargetUID types.UID, syncTargetName string) string {
+	syncerHash := sha256.Sum224([]byte(syncTargetUID))
+	uid36hash := strings.ToLower(base36.EncodeBytes(syncerHash[:]))
+	workspaceHash := sha256.Sum224([]byte(clusterName.String()))
+	workspace36hash := strings.ToLower(base36.EncodeBytes(workspaceHash[:]))
+
+	return fmt.Sprintf("kcp-dns-%s-%s-%s", syncTargetName, uid36hash[:8], workspace36hash[:8])
+}
+
+// GetTenantID encodes the KCP tenant to which the namespace designated by the given
+// NamespaceLocator belongs. It is based on the NamespaceLocator, but with an empty
+// namespace value. The value will be the same for all downstream namespaces originating
+// from the same KCP workspace / SyncTarget.
+// The encoding is repeatable.
+func GetTenantID(l NamespaceLocator) (string, error) {
+	clusterWideLocator := NamespaceLocator{
+		SyncTarget:  l.SyncTarget,
+		ClusterName: l.ClusterName,
+	}
+
+	b, err := json.Marshal(clusterWideLocator)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum224(b)
+	var i big.Int
+	i.SetBytes(hash[:])
+	return i.Text(62), nil
+}
+
+func ContainsGVR(gvrs []schema.GroupVersionResource, gvr schema.GroupVersionResource) bool {
+	for _, item := range gvrs {
+		if gvr == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/syncer/shared/helpers_test.go
+++ b/pkg/syncer/shared/helpers_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetUpstreamResourceName(t *testing.T) {
+	tests := []struct {
+		name     string
+		gvr      schema.GroupVersionResource
+		resource string
+		want     string
+	}{
+		{
+			name:     "kcp-root-ca.crt configmap, should be translated to kube-root-ca.crt",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "kcp-root-ca.crt",
+			want:     "kube-root-ca.crt",
+		},
+		{
+			name:     "not kcp-root-ca.crt configmap, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "my-configmap",
+			want:     "my-configmap",
+		},
+		{
+			name:     "a default token secret with kcp prefix, should be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			resource: "kcp-default-token-1234",
+			want:     "default-token-1234",
+		},
+		{
+			name:     "a non default token secret without kcp prefix, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			resource: "my-super-secret",
+			want:     "my-super-secret",
+		},
+		{
+			name:     "a different GVR than configmap or secret, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "random", Version: "v1", Resource: "another"},
+			resource: "kcp-foo",
+			want:     "kcp-foo",
+		},
+		{
+			name:     "a configmap with a kcp prefix, shouldn't be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "kcp-default-token-1234",
+			want:     "kcp-default-token-1234",
+		},
+		{
+			name:     "invalid GVR, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "", Resource: ""},
+			resource: "kcp-foo",
+			want:     "kcp-foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetUpstreamResourceName(tt.gvr, tt.resource); got != tt.want {
+				t.Errorf("GetUpstreamResourceName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/syncer/shared/namespace.go
+++ b/pkg/syncer/shared/namespace.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/martinlindhe/base36"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	NamespaceLocatorAnnotation = "kcp.io/namespace-locator"
+	TenantIDLabel              = "kcp.io/tenant-id"
+)
+
+// NamespaceLocator stores a logical cluster and namespace and is used
+// as the source for the mapped namespace name in a physical cluster.
+type NamespaceLocator struct {
+	SyncTarget  SyncTargetLocator   `json:"syncTarget"`
+	ClusterName logicalcluster.Name `json:"cluster,omitempty"`
+	Namespace   string              `json:"namespace"`
+}
+
+type SyncTargetLocator struct {
+	ClusterName    string    `json:"cluster,omitempty"`
+	DeprecatedPath string    `json:"path,omitempty"`
+	Name           string    `json:"name"`
+	UID            types.UID `json:"uid"`
+}
+
+func NewNamespaceLocator(workspace, syncTargetClusterName logicalcluster.Name, syncTargetUID types.UID, syncTargetName, upstreamNamespace string) NamespaceLocator {
+	return NamespaceLocator{
+		SyncTarget: SyncTargetLocator{
+			ClusterName: syncTargetClusterName.String(),
+			Name:        syncTargetName,
+			UID:         syncTargetUID,
+		},
+		ClusterName: workspace,
+		Namespace:   upstreamNamespace,
+	}
+}
+
+func NewNamespaceLocatorV060(workspace, syncTargetClusterName logicalcluster.Name, syncTargetUID types.UID, syncTargetName, upstreamNamespace string) NamespaceLocator {
+	return NamespaceLocator{
+		SyncTarget: SyncTargetLocator{
+			DeprecatedPath: syncTargetClusterName.String(),
+			Name:           syncTargetName,
+			UID:            syncTargetUID,
+		},
+		ClusterName: workspace,
+		Namespace:   upstreamNamespace,
+	}
+}
+
+func LocatorFromAnnotations(annotations map[string]string) (*NamespaceLocator, bool, error) {
+	annotation, ok := annotations[NamespaceLocatorAnnotation]
+	if !ok {
+		return nil, false, nil
+	}
+	var locator NamespaceLocator
+	if err := json.Unmarshal([]byte(annotation), &locator); err != nil {
+		return nil, false, err
+	}
+
+	// get us from v0.6.0 locators (using syncTarget.path) to v0.6.1+ (using syncTarget.workspace)
+	if locator.SyncTarget.ClusterName == "" {
+		locator.SyncTarget.ClusterName = locator.SyncTarget.DeprecatedPath
+	}
+	locator.SyncTarget.DeprecatedPath = ""
+
+	return &locator, true, nil
+}
+
+// PhysicalClusterNamespaceName encodes the NamespaceLocator into a new
+// namespace name for use on a physical cluster. The encoding is repeatable.
+func PhysicalClusterNamespaceName(l NamespaceLocator) (string, error) {
+	b, err := json.Marshal(l)
+	if err != nil {
+		return "", err
+	}
+	// hash the marshalled locator
+	hash := sha256.Sum224(b)
+	// convert the hash to base36 (alphanumeric) to decrease collision probabilities
+	base36hash := strings.ToLower(base36.EncodeBytes(hash[:]))
+	// use 12 chars of the base36hash, should be enough to avoid collisions and
+	// keep the namespaces short enough.
+	return fmt.Sprintf("kcp-%s", base36hash[:12]), nil
+}

--- a/pkg/syncer/shared/namespace_test.go
+++ b/pkg/syncer/shared/namespace_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+func TestLocatorFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        *NamespaceLocator
+		wantFound   bool
+		wantErrs    []string
+	}{
+		{
+			name:      "no annotation",
+			wantFound: false,
+		},
+		{
+			name: "garbage",
+			annotations: map[string]string{
+				NamespaceLocatorAnnotation: "garbage",
+			},
+			wantErrs: []string{"invalid character"},
+		},
+		{
+			name: "happy case",
+			annotations: map[string]string{
+				NamespaceLocatorAnnotation: `{"syncTarget":{"cluster":"test-workspace","name":"test-name","uid":"test-uid"},"cluster":"test-workspace","namespace":"test-namespace"}`,
+			},
+			want: &NamespaceLocator{
+				SyncTarget: SyncTargetLocator{
+					ClusterName: "test-workspace",
+					Name:        "test-name",
+					UID:         "test-uid",
+				},
+				ClusterName: logicalcluster.Name("test-workspace"),
+				Namespace:   "test-namespace",
+			},
+			wantFound: true,
+		},
+		{
+			name: "format up to v0.6.0",
+			annotations: map[string]string{
+				NamespaceLocatorAnnotation: `{"syncTarget":{"path":"test-workspace","name":"test-name","uid":"test-uid"},"cluster":"test-workspace","namespace":"test-namespace"}`,
+			},
+			want: &NamespaceLocator{
+				SyncTarget: SyncTargetLocator{
+					ClusterName: "test-workspace",
+					Name:        "test-name",
+					UID:         "test-uid",
+				},
+				ClusterName: logicalcluster.Name("test-workspace"),
+				Namespace:   "test-namespace",
+			},
+			wantFound: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotFound, err := LocatorFromAnnotations(tt.annotations)
+			if (err != nil) != (len(tt.wantErrs) > 0) {
+				t.Errorf("LocatorFromAnnotations() error = %q, wantErrs %v", err.Error(), tt.wantErrs)
+				return
+			} else if err != nil {
+				for _, wantErr := range tt.wantErrs {
+					if !strings.Contains(err.Error(), wantErr) {
+						t.Errorf("LocatorFromAnnotations() error = %q, wantErrs %q", err.Error(), wantErr)
+						return
+					}
+				}
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LocatorFromAnnotations() got = %v, want %v", got, tt.want)
+			}
+			if gotFound != tt.wantFound {
+				t.Errorf("LocatorFromAnnotations() gotFound = %v, want %v", gotFound, tt.wantFound)
+			}
+		})
+	}
+}

--- a/pkg/syncer/spec/dns/deployment_dns.yaml
+++ b/pkg/syncer/spec/dns/deployment_dns.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Name
+  namespace: Namespace
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: Name
+  template:
+    metadata:
+      labels:
+        app: Name
+    spec:
+      containers:
+        - name: kcp-dns
+          command:
+            - /ko-app/syncer
+          args:
+            - dns
+            - start
+            - --configmap-name
+            - ConfigMapName
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: Image
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: Name

--- a/pkg/syncer/spec/dns/dns_process.go
+++ b/pkg/syncer/spec/dns/dns_process.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubernetesinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersappsv1 "k8s.io/client-go/listers/apps/v1"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	listersnetworkingv1 "k8s.io/client-go/listers/networking/v1"
+	listersrbacv1 "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+type DNSProcessor struct {
+	downstreamKubeClient kubernetes.Interface
+
+	serviceAccountLister listerscorev1.ServiceAccountLister
+	roleLister           listersrbacv1.RoleLister
+	roleBindingLister    listersrbacv1.RoleBindingLister
+	deploymentLister     listersappsv1.DeploymentLister
+	serviceLister        listerscorev1.ServiceLister
+	endpointLister       listerscorev1.EndpointsLister
+	networkPolicyLister  listersnetworkingv1.NetworkPolicyLister
+
+	syncTargetUID  types.UID
+	syncTargetName string
+	dnsNamespace   string // namespace containing all DNS objects
+	dnsImage       string
+
+	initialized      sync.Map
+	initializationMu sync.RWMutex
+}
+
+func NewDNSProcessor(
+	downstreamKubeClient kubernetes.Interface,
+	syncerNamespaceInformerFactory kubernetesinformers.SharedInformerFactory,
+	syncTargetName string,
+	syncTargetUID types.UID,
+	dnsNamespace string,
+	dnsImage string) *DNSProcessor {
+	return &DNSProcessor{
+		downstreamKubeClient: downstreamKubeClient,
+		serviceAccountLister: syncerNamespaceInformerFactory.Core().V1().ServiceAccounts().Lister(),
+		roleLister:           syncerNamespaceInformerFactory.Rbac().V1().Roles().Lister(),
+		roleBindingLister:    syncerNamespaceInformerFactory.Rbac().V1().RoleBindings().Lister(),
+		deploymentLister:     syncerNamespaceInformerFactory.Apps().V1().Deployments().Lister(),
+		serviceLister:        syncerNamespaceInformerFactory.Core().V1().Services().Lister(),
+		endpointLister:       syncerNamespaceInformerFactory.Core().V1().Endpoints().Lister(),
+		networkPolicyLister:  syncerNamespaceInformerFactory.Networking().V1().NetworkPolicies().Lister(),
+		syncTargetName:       syncTargetName,
+		syncTargetUID:        syncTargetUID,
+		dnsNamespace:         dnsNamespace,
+		dnsImage:             dnsImage,
+	}
+}
+
+func (d *DNSProcessor) ServiceLister() listerscorev1.ServiceLister {
+	return d.serviceLister
+}
+
+// EnsureDNSUpAndReady creates all DNS-related resources if necessary.
+// It also checks that the DNS Deployment for this workspace
+// are effectively reachable through the Service.
+// It returns true if the DNS is setup and reachable, and returns an error if there was an error
+// during the check or creation of the DNS-related resources.
+func (d *DNSProcessor) EnsureDNSUpAndReady(ctx context.Context, namespaceLocator shared.NamespaceLocator) (bool, error) {
+	logger := klog.FromContext(ctx)
+	logger = logger.WithName("dns")
+
+	dnsID := shared.GetDNSID(namespaceLocator.ClusterName, d.syncTargetUID, d.syncTargetName)
+	logger = logger.WithValues("name", dnsID, "namespace", d.dnsNamespace)
+
+	logger.V(4).Info("checking if all dns objects exist and are up-to-date")
+	ctx = klog.NewContext(ctx, logger)
+
+	// Try updating resources if not done already
+	if initialized, ok := d.initialized.Load(dnsID); !ok || !initialized.(bool) {
+		updated, err := d.lockMayUpdate(ctx, dnsID)
+		if updated {
+			return false, err
+		}
+	}
+
+	// Get the expected Endpoints resource
+	endpoints, err := d.endpointLister.Endpoints(d.dnsNamespace).Get(dnsID)
+	if err == nil {
+		// DNS is ready if the Endpoints resource has at least one ready address
+		return hasAtLeastOneReadyAddress(endpoints), nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	// No Endpoints resource was found: try to create all the DNS-related resources
+	if err := d.processServiceAccount(ctx, dnsID); err != nil {
+		return false, err
+	}
+	if err := d.processRole(ctx, dnsID); err != nil {
+		return false, err
+	}
+	if err := d.processRoleBinding(ctx, dnsID); err != nil {
+		return false, err
+	}
+	if err := d.processDeployment(ctx, dnsID); err != nil {
+		return false, err
+	}
+	if err := d.processService(ctx, dnsID); err != nil {
+		return false, err
+	}
+	if err := d.processNetworkPolicy(ctx, dnsID, namespaceLocator); err != nil {
+		return false, err
+	}
+
+	// Since the Endpoints resource was not found, the DNS is not yet ready,
+	// even though all the required resources have been created
+	// (deployment still needs to start).
+	return false, nil
+}
+
+func (d *DNSProcessor) processServiceAccount(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := d.serviceAccountLister.ServiceAccounts(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		expected := MakeServiceAccount(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.CoreV1().ServiceAccounts(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("ServiceAccount created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get ServiceAccount (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNSProcessor) processRole(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := d.roleLister.Roles(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		expected := MakeRole(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.RbacV1().Roles(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("Role created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get Role (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNSProcessor) processRoleBinding(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := d.roleBindingLister.RoleBindings(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		expected := MakeRoleBinding(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.RbacV1().RoleBindings(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("RoleBinding created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get RoleBinding (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNSProcessor) processDeployment(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := d.deploymentLister.Deployments(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		expected := MakeDeployment(name, d.dnsNamespace, d.dnsImage)
+		_, err = d.downstreamKubeClient.AppsV1().Deployments(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("Deployment created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get Deployment (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNSProcessor) processService(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	_, err := d.serviceLister.Services(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		expected := MakeService(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.CoreV1().Services(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("Service created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get Service (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func (d *DNSProcessor) processNetworkPolicy(ctx context.Context, name string, namespaceLocator shared.NamespaceLocator) error {
+	logger := klog.FromContext(ctx)
+
+	var kubeEndpoints *corev1.Endpoints
+	_, err := d.networkPolicyLister.NetworkPolicies(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		kubeEndpoints, err = d.downstreamKubeClient.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(kubeEndpoints.Subsets) == 0 || len(kubeEndpoints.Subsets[0].Addresses) == 0 {
+			return errors.New("missing kubernetes API endpoints")
+		}
+
+		tenantID, err := shared.GetTenantID(namespaceLocator)
+		if err != nil {
+			return err
+		}
+
+		expected := MakeNetworkPolicy(name, d.dnsNamespace, tenantID, &kubeEndpoints.Subsets[0])
+		_, err = d.downstreamKubeClient.NetworkingV1().NetworkPolicies(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("NetworkPolicy created")
+		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		logger.Error(err, "failed to get NetworkPolicy (retrying)")
+		return err
+	}
+
+	return nil
+}
+
+func hasAtLeastOneReadyAddress(endpoints *corev1.Endpoints) bool {
+	for _, s := range endpoints.Subsets {
+		if len(s.Addresses) > 0 && s.Addresses[0].IP != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// lockMayUpdate guarantees mayUpdate is run in a critical section.
+// It returns true when the DNS deployment has been updated.
+func (d *DNSProcessor) lockMayUpdate(ctx context.Context, dnsID string) (bool, error) {
+	d.initializationMu.Lock()
+	defer d.initializationMu.Unlock()
+
+	// initialized may have been modified outside the critical section so checking again here
+	if initialized, ok := d.initialized.Load(dnsID); !ok || !initialized.(bool) {
+		updated, err := d.mayUpdate(ctx, dnsID)
+
+		if err != nil {
+			return true, err
+		}
+
+		d.initialized.Store(dnsID, true)
+
+		if updated {
+			// The endpoint might temporarily be without ready addresses, depending on the
+			// deployment strategy. Anyhow, gives some time for the system to stabilize
+
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (d *DNSProcessor) mayUpdate(ctx context.Context, name string) (bool, error) {
+	deployment, err := d.deploymentLister.Deployments(d.dnsNamespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	deployment = deployment.DeepCopy()
+	needsUpdate := false
+	c := findContainer(deployment, "kcp-dns")
+
+	if c == nil {
+		// corrupted deployment. Trying to recover
+		expected := MakeDeployment(name, d.dnsNamespace, d.dnsImage)
+		deployment.Spec = expected.Spec
+		needsUpdate = true
+	} else if c.Image != d.dnsImage {
+		c.Image = d.dnsImage
+		needsUpdate = true
+	}
+
+	if !needsUpdate {
+		return false, nil
+	}
+
+	logger := klog.FromContext(ctx)
+
+	_, err = d.downstreamKubeClient.AppsV1().Deployments(d.dnsNamespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "failed to update Deployment (retrying)")
+		return false, err
+	}
+
+	logger.Info("Deployment updated")
+	return true, nil
+}
+
+func findContainer(deployment *appsv1.Deployment, name string) *corev1.Container {
+	containers := deployment.Spec.Template.Spec.Containers
+
+	for i := 0; i < len(containers); i++ {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}

--- a/pkg/syncer/spec/dns/dns_process_test.go
+++ b/pkg/syncer/spec/dns/dns_process_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+var (
+	scheme            *runtime.Scheme
+	serviceAccountGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"}
+	roleGVR           = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
+	roleBindingGVR    = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	serviceGVR        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	deploymentGVR     = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	endpointGVR       = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}
+	networkPolicyGVR  = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+}
+
+func TestDNSProcess(t *testing.T) {
+	clusterName := logicalcluster.Name("root")
+	syncTargetClusterName := logicalcluster.Name("targetclustername")
+	syncTargetUID := types.UID("targetuid")
+	syncTargetName := "targetname"
+
+	locator := shared.NewNamespaceLocator(clusterName, syncTargetClusterName, syncTargetUID, syncTargetName, "")
+	tenantID, err := shared.GetTenantID(locator)
+	require.NoError(t, err)
+
+	dnsID := shared.GetDNSID(clusterName, syncTargetUID, syncTargetName)
+	dnsns := "dnsns"
+
+	tests := map[string]struct {
+		resources     []runtime.Object
+		initialized   bool
+		expectReady   bool
+		expectActions []clienttesting.Action
+		dnsImage      string
+	}{
+		"endpoint is ready": {
+			resources: []runtime.Object{
+				endpoints(dnsID, dnsns, "8.8.8.8"),
+			},
+			expectReady:   true,
+			expectActions: []clienttesting.Action{},
+			initialized:   true,
+			dnsImage:      "dnsimage",
+		},
+		"endpoint exists but not ready": {
+			resources: []runtime.Object{
+				endpoints(dnsID, dnsns, ""),
+			},
+			expectReady:   false,
+			expectActions: []clienttesting.Action{},
+			initialized:   true,
+			dnsImage:      "dnsimage",
+		},
+		"endpoint exist, DNS objects exists, updating with no changes": {
+			resources: []runtime.Object{
+				MakeServiceAccount(dnsID, dnsns),
+				MakeRole(dnsID, dnsns),
+				MakeRoleBinding(dnsID, dnsns),
+				MakeService(dnsID, dnsns),
+				MakeDeployment(dnsID, dnsns, "dnsimage"),
+				endpoints(dnsID, dnsns, "8.8.8.8"),
+				MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{}),
+			},
+			expectReady:   true,
+			expectActions: []clienttesting.Action{},
+			initialized:   false,
+			dnsImage:      "dnsimage",
+		},
+		"endpoint exist, DNS objects exists, updating with changes": {
+			resources: []runtime.Object{
+				MakeServiceAccount(dnsID, dnsns),
+				MakeRole(dnsID, dnsns),
+				MakeRoleBinding(dnsID, dnsns),
+				MakeService(dnsID, dnsns),
+				MakeDeployment(dnsID, dnsns, "dnsimage"),
+				endpoints(dnsID, dnsns, "8.8.8.8"),
+				MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{}),
+			},
+			expectReady: false,
+			expectActions: []clienttesting.Action{
+				clienttesting.NewUpdateAction(deploymentGVR, dnsns, MakeDeployment(dnsID, dnsns, "newdnsimage")),
+			},
+			initialized: false,
+			dnsImage:    "newdnsimage",
+		},
+		"endpoint does not exist, no DNS objects": {
+			resources: []runtime.Object{
+				endpoints("kubernetes", "default", "10.0.0.0"),
+			},
+			expectReady: false,
+			expectActions: []clienttesting.Action{
+				clienttesting.NewCreateAction(serviceAccountGVR, dnsns, MakeServiceAccount(dnsID, dnsns)),
+				clienttesting.NewCreateAction(roleGVR, dnsns, MakeRole(dnsID, dnsns)),
+				clienttesting.NewCreateAction(roleBindingGVR, dnsns, MakeRoleBinding(dnsID, dnsns)),
+				clienttesting.NewCreateAction(deploymentGVR, dnsns, MakeDeployment(dnsID, dnsns, "dnsimage")),
+				clienttesting.NewCreateAction(serviceGVR, dnsns, MakeService(dnsID, dnsns)),
+				clienttesting.NewGetAction(endpointGVR, "default", "kubernetes"),
+				clienttesting.NewCreateAction(networkPolicyGVR, dnsns, MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{
+					Addresses: []corev1.EndpointAddress{{IP: "10.0.0.0"}},
+				})),
+			},
+			initialized: true,
+			dnsImage:    "dnsimage",
+		},
+		"endpoint does not exist, DNS objects exists, no updates": {
+			resources: []runtime.Object{
+				MakeServiceAccount(dnsID, dnsns),
+				MakeRole(dnsID, dnsns),
+				MakeRoleBinding(dnsID, dnsns),
+				MakeService(dnsID, dnsns),
+				MakeDeployment(dnsID, dnsns, "dnsimage"),
+				MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{}),
+			},
+			expectReady:   false,
+			expectActions: []clienttesting.Action{},
+			initialized:   true,
+			dnsImage:      "dnsimage",
+		},
+		"endpoint does not exist, DNS objects exists, updating with no changes": {
+			resources: []runtime.Object{
+				MakeServiceAccount(dnsID, dnsns),
+				MakeRole(dnsID, dnsns),
+				MakeRoleBinding(dnsID, dnsns),
+				MakeService(dnsID, dnsns),
+				MakeDeployment(dnsID, dnsns, "dnsimage"),
+				MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{}),
+			},
+			expectReady:   false,
+			expectActions: []clienttesting.Action{},
+			initialized:   false,
+			dnsImage:      "dnsimage",
+		},
+		"endpoint does not exist, DNS objects exists, updating with changes": {
+			resources: []runtime.Object{
+				MakeServiceAccount(dnsID, dnsns),
+				MakeRole(dnsID, dnsns),
+				MakeRoleBinding(dnsID, dnsns),
+				MakeService(dnsID, dnsns),
+				MakeDeployment(dnsID, dnsns, "dnsimage"),
+				MakeNetworkPolicy(dnsID, dnsns, tenantID, &corev1.EndpointSubset{}),
+			},
+			expectReady: false,
+			expectActions: []clienttesting.Action{
+				clienttesting.NewUpdateAction(deploymentGVR, dnsns, MakeDeployment(dnsID, dnsns, "newdnsimage")),
+			},
+			initialized: false,
+			dnsImage:    "newdnsimage",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			kubeClient := kubefake.NewSimpleClientset(tc.resources...)
+
+			// informerFactory to watch some DNS-related resources in the dns namespace
+			informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Hour, informers.WithNamespace(dnsns))
+
+			controller := NewDNSProcessor(kubeClient, informerFactory, syncTargetName, syncTargetUID,
+				dnsns, tc.dnsImage)
+
+			controller.initialized.Store(dnsID, tc.initialized)
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			kubeClient.ClearActions()
+
+			ready, err := controller.EnsureDNSUpAndReady(ctx, locator)
+			assert.NoError(t, err)
+
+			assert.Empty(t, cmp.Diff(tc.expectReady, ready))
+			assert.Empty(t, cmp.Diff(tc.expectActions, kubeClient.Actions()))
+		})
+	}
+}
+
+func TestMultipleDNSInitialization(t *testing.T) {
+	syncTargetClusterName := logicalcluster.Name("targetclustername")
+	syncTargetUID := types.UID("targetuid")
+	syncTargetName := "targetname"
+	dnsns := "dnsns"
+
+	clusterName1 := logicalcluster.Name("root1")
+	clusterName2 := logicalcluster.Name("root2")
+
+	locator1 := shared.NewNamespaceLocator(clusterName1, syncTargetClusterName, syncTargetUID, syncTargetName, "")
+	locator2 := shared.NewNamespaceLocator(clusterName2, syncTargetClusterName, syncTargetUID, syncTargetName, "")
+
+	dnsID1 := shared.GetDNSID(clusterName1, syncTargetUID, syncTargetName)
+	dnsID2 := shared.GetDNSID(clusterName2, syncTargetUID, syncTargetName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kubeClient := kubefake.NewSimpleClientset(
+		endpoints(dnsID1, dnsns, "8.8.8.8"),
+		endpoints(dnsID2, dnsns, "8.8.8.9"))
+
+	// informerFactory to watch some DNS-related resources in the dns namespace
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, time.Hour, informers.WithNamespace(dnsns))
+
+	controller := NewDNSProcessor(kubeClient, informerFactory, syncTargetName, syncTargetUID,
+		dnsns, "animage")
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	ready, err := controller.EnsureDNSUpAndReady(ctx, locator1)
+	assert.NoError(t, err)
+	assert.True(t, ready)
+	init1, _ := controller.initialized.Load(dnsID1)
+	assert.True(t, init1.(bool))
+	init2, _ := controller.initialized.Load(dnsID2)
+	assert.Nil(t, init2)
+
+	ready, err = controller.EnsureDNSUpAndReady(ctx, locator2)
+	assert.NoError(t, err)
+	assert.True(t, ready)
+	init1, _ = controller.initialized.Load(dnsID1)
+	assert.True(t, init1.(bool))
+	init2, _ = controller.initialized.Load(dnsID2)
+	assert.True(t, init2.(bool))
+}
+
+func endpoints(name, namespace, ip string) *corev1.Endpoints {
+	endpoint := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if ip != "" {
+		endpoint.Subsets = []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: ip,
+					}},
+			},
+		}
+	}
+	return endpoint
+}

--- a/pkg/syncer/spec/dns/networkpolicy_dns.yaml
+++ b/pkg/syncer/spec/dns/networkpolicy_dns.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: Name
+  namespace: Namespace
+spec:
+  podSelector:
+    matchLabels:
+      app: Name
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kcp.io/tenant-id: TenantID
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+  egress:
+    # Only give access to coredns in kube-system
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+     # Give access to the API server to watch its associated configmap
+    - to:
+      # one ipBlock per IP (dynamically filled)
+      - ipBlock:
+          cidr: APIServerIP
+      ports:
+        - protocol: TCP
+          port: 6443
+

--- a/pkg/syncer/spec/dns/resources.go
+++ b/pkg/syncer/spec/dns/resources.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+//go:embed *.yaml
+var dnsFiles embed.FS
+
+var (
+	serviceAccountTemplate corev1.ServiceAccount
+	roleTemplate           rbacv1.Role
+	roleBindingTemplate    rbacv1.RoleBinding
+	deploymentTemplate     appsv1.Deployment
+	serviceTemplate        corev1.Service
+	networkPolicyTemplate  networkingv1.NetworkPolicy
+)
+
+func init() {
+	loadTemplateOrDie("serviceaccount_dns.yaml", &serviceAccountTemplate)
+	loadTemplateOrDie("role_dns.yaml", &roleTemplate)
+	loadTemplateOrDie("rolebinding_dns.yaml", &roleBindingTemplate)
+	loadTemplateOrDie("deployment_dns.yaml", &deploymentTemplate)
+	loadTemplateOrDie("service_dns.yaml", &serviceTemplate)
+	loadTemplateOrDie("networkpolicy_dns.yaml", &networkPolicyTemplate)
+}
+
+func MakeServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	sa := serviceAccountTemplate.DeepCopy()
+
+	sa.Name = name
+	sa.Namespace = namespace
+
+	return sa
+}
+
+func MakeRole(name, namespace string) *rbacv1.Role {
+	role := roleTemplate.DeepCopy()
+
+	role.Name = name
+	role.Namespace = namespace
+	role.Rules[0].ResourceNames[0] = name
+
+	return role
+}
+
+func MakeRoleBinding(name, namespace string) *rbacv1.RoleBinding {
+	roleBinding := roleBindingTemplate.DeepCopy()
+
+	roleBinding.Name = name
+	roleBinding.Namespace = namespace
+	roleBinding.RoleRef.Name = name
+	roleBinding.Subjects[0].Name = name
+	roleBinding.Subjects[0].Namespace = namespace
+
+	return roleBinding
+}
+
+func MakeDeployment(name, namespace, image string) *appsv1.Deployment {
+	deployment := deploymentTemplate.DeepCopy()
+
+	deployment.Name = name
+	deployment.Namespace = namespace
+	deployment.Spec.Selector.MatchLabels["app"] = name
+	deployment.Spec.Template.Labels["app"] = name
+	deployment.Spec.Template.Spec.Containers[0].Image = image
+	deployment.Spec.Template.Spec.Containers[0].Args[3] = name
+	deployment.Spec.Template.Spec.ServiceAccountName = name
+
+	return deployment
+}
+
+func MakeService(name, namespace string) *corev1.Service {
+	service := serviceTemplate.DeepCopy()
+
+	service.Name = name
+	service.Namespace = namespace
+	service.Labels["app"] = name
+	service.Spec.Selector["app"] = name
+
+	return service
+}
+
+func MakeNetworkPolicy(name, namespace, tenantID string, kubeEndpoints *corev1.EndpointSubset) *networkingv1.NetworkPolicy {
+	np := networkPolicyTemplate.DeepCopy()
+
+	np.Name = name
+	np.Namespace = namespace
+	np.Spec.PodSelector.MatchLabels["app"] = name
+	np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[shared.TenantIDLabel] = tenantID
+
+	to := make([]networkingv1.NetworkPolicyPeer, len(kubeEndpoints.Addresses))
+	for i, endpoint := range kubeEndpoints.Addresses {
+		to[i] = networkingv1.NetworkPolicyPeer{
+			IPBlock: &networkingv1.IPBlock{
+				CIDR: endpoint.IP + "/32",
+			},
+		}
+	}
+	np.Spec.Egress[1].To = to
+
+	ports := make([]networkingv1.NetworkPolicyPort, len(kubeEndpoints.Ports))
+	for i, port := range kubeEndpoints.Ports {
+		pport := intstr.FromInt(int(port.Port))
+		ports[i].Port = &pport
+		pprotocol := port.Protocol
+		ports[i].Protocol = &pprotocol
+	}
+	np.Spec.Egress[1].Ports = ports
+
+	return np
+}
+
+// load a YAML resource into a typed kubernetes object.
+func loadTemplateOrDie(filename string, obj interface{}) {
+	raw, err := dnsFiles.ReadFile(filename)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read file: %v", err))
+	}
+	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewReader(raw))
+
+	var u unstructured.Unstructured
+	err = decoder.Decode(&u)
+	if err != nil {
+		panic(fmt.Sprintf("failed to decode file: %v", err))
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert object: %v", err))
+	}
+}

--- a/pkg/syncer/spec/dns/role_dns.yaml
+++ b/pkg/syncer/spec/dns/role_dns.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: Name
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - ConfigMapName
+    verbs:
+      - "get"
+      - "list"
+      - "watch"

--- a/pkg/syncer/spec/dns/rolebinding_dns.yaml
+++ b/pkg/syncer/spec/dns/rolebinding_dns.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: Name
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: Name
+subjects:
+  - kind: ServiceAccount
+    name: Name
+    namespace: Name

--- a/pkg/syncer/spec/dns/service_dns.yaml
+++ b/pkg/syncer/spec/dns/service_dns.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: Name
+  namespace: Namespace
+  labels:
+    app: Name
+spec:
+  type: ClusterIP
+  selector:
+    app: Name
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+      targetPort: 5353
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 5353

--- a/pkg/syncer/spec/dns/serviceaccount_dns.yaml
+++ b/pkg/syncer/spec/dns/serviceaccount_dns.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: Name
+  namespace: Namespace

--- a/pkg/syncer/spec/mutators/podspecable.go
+++ b/pkg/syncer/spec/mutators/podspecable.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	utilspointer "k8s.io/utils/pointer"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+type ListSecretFunc func(clusterName logicalcluster.Name, namespace string) ([]runtime.Object, error)
+type GetWorkspaceURLFunc func(obj *unstructured.Unstructured) (*url.URL, error)
+type GetClusterDDSIFFunc func(clusterName logicalcluster.Name) (*ddsif.DiscoveringDynamicSharedInformerFactory, error)
+
+type PodSpecableMutator struct {
+	getWorkspaceURL       GetWorkspaceURLFunc
+	listSecrets           ListSecretFunc
+	serviceLister         listerscorev1.ServiceLister
+	syncTargetClusterName logicalcluster.Name
+	syncTargetUID         types.UID
+	syncTargetName        string
+	dnsNamespace          string
+	upsyncPods            bool
+}
+
+func (dm *PodSpecableMutator) GVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "statefulsets",
+		},
+		{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "replicasets",
+		},
+	}
+}
+
+func NewPodspecableMutator(ddsifForUpstreamSyncer GetClusterDDSIFFunc, serviceLister listerscorev1.ServiceLister,
+	syncTargetClusterName logicalcluster.Name, syncTargetName string, syncTargetUID types.UID,
+	dnsNamespace string, upsyncPods bool) *PodSpecableMutator {
+	secretsGVR := corev1.SchemeGroupVersion.WithResource("secrets")
+	return &PodSpecableMutator{
+		getWorkspaceURL: func(obj *unstructured.Unstructured) (*url.URL, error) {
+			workspaceURL, ok := obj.GetAnnotations()[workloadv1alpha1.InternalWorkspaceURLAnnotationKey]
+			if !ok {
+				return nil, fmt.Errorf("annotation %q not found on %s|%s/%s", workloadv1alpha1.InternalWorkspaceURLAnnotationKey, logicalcluster.From(obj), obj.GetNamespace(), obj.GetName())
+			}
+			return url.Parse(workspaceURL)
+		},
+		listSecrets: func(clusterName logicalcluster.Name, namespace string) ([]runtime.Object, error) {
+			ddsif, err := ddsifForUpstreamSyncer(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			informers, notSynced := ddsif.Informers()
+			informer, ok := informers[secretsGVR]
+			if !ok {
+				if shared.ContainsGVR(notSynced, secretsGVR) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the upstream syncer informer factory", secretsGVR)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the upstream syncer informer factory", secretsGVR)
+			}
+			return informer.Lister().ByCluster(clusterName).ByNamespace(namespace).List(labels.Everything())
+		},
+		serviceLister:         serviceLister,
+		syncTargetClusterName: syncTargetClusterName,
+		syncTargetUID:         syncTargetUID,
+		syncTargetName:        syncTargetName,
+		dnsNamespace:          dnsNamespace,
+		upsyncPods:            upsyncPods,
+	}
+}
+
+// Mutate applies the mutator changes to the object.
+func (dm *PodSpecableMutator) Mutate(obj *unstructured.Unstructured) error {
+	podTemplateUnstr, ok, err := unstructured.NestedMap(obj.UnstructuredContent(), "spec", "template")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("object should have a PodTemplate.Spec 'spec.template', but doesn't: %v", obj)
+	}
+
+	podTemplate := &corev1.PodTemplateSpec{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(
+		podTemplateUnstr,
+		&podTemplate)
+	if err != nil {
+		return err
+	}
+	upstreamLogicalName := logicalcluster.From(obj)
+
+	desiredServiceAccountName := "default"
+	if podTemplate.Spec.ServiceAccountName != "" && podTemplate.Spec.ServiceAccountName != "default" {
+		desiredServiceAccountName = podTemplate.Spec.ServiceAccountName
+	}
+
+	rawSecretList, err := dm.listSecrets(upstreamLogicalName, obj.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("error listing secrets for workspace %s: %w", upstreamLogicalName.String(), err)
+	}
+
+	secretList := make([]*unstructured.Unstructured, 0, len(rawSecretList))
+	for i := range rawSecretList {
+		secretList = append(secretList, rawSecretList[i].(*unstructured.Unstructured))
+	}
+
+	// In order to avoid triggering a deployment update on resyncs, we need to make sure that the list
+	// of secrets is sorted by creationTimsestamp. So if the user creates a new token for a given serviceaccount
+	// the first one will be picked always.
+	sort.Slice(secretList, func(i, j int) bool {
+		iCreationTimestamp := secretList[i].GetCreationTimestamp()
+		jCreationTimestamp := secretList[j].GetCreationTimestamp()
+		return iCreationTimestamp.Before(&jCreationTimestamp)
+	})
+
+	desiredSecretName := ""
+	for _, secret := range secretList {
+		// Find the SA token that matches the service account name.
+		if val, ok := secret.GetAnnotations()[corev1.ServiceAccountNameKey]; ok && val == desiredServiceAccountName {
+			if desiredServiceAccountName == "default" {
+				desiredSecretName = "kcp-" + secret.GetName()
+				break
+			}
+			desiredSecretName = secret.GetName()
+			break
+		}
+	}
+
+	if desiredSecretName == "" {
+		return fmt.Errorf("couldn't find a token upstream for the serviceaccount %s/%s in workspace %s", desiredServiceAccountName, obj.GetNamespace(), upstreamLogicalName.String())
+	}
+
+	// Setting AutomountServiceAccountToken to false allow us to control the ServiceAccount
+	// VolumeMount and Volume definitions.
+	podTemplate.Spec.AutomountServiceAccountToken = utilspointer.Bool(false)
+	// Set to empty the serviceAccountName on podTemplate as we are not syncing the serviceAccount down to the workload cluster.
+	podTemplate.Spec.ServiceAccountName = ""
+
+	workspaceURL, err := dm.getWorkspaceURL(obj)
+	if err != nil {
+		return err
+	}
+
+	kcpExternalHost := workspaceURL.Hostname()
+	kcpExternalPort := workspaceURL.Port()
+
+	overrideEnvs := []corev1.EnvVar{
+		{Name: "KUBERNETES_SERVICE_PORT", Value: kcpExternalPort},
+		{Name: "KUBERNETES_SERVICE_PORT_HTTPS", Value: kcpExternalPort},
+		{Name: "KUBERNETES_SERVICE_HOST", Value: kcpExternalHost},
+	}
+
+	// This is the VolumeMount that we will append to all the containers of the deployment
+	serviceAccountMount := corev1.VolumeMount{
+		Name:      "kcp-api-access",
+		MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		ReadOnly:  true,
+	}
+
+	// This is the Volume that we will add to the Deployment in order to control
+	// the name of the ca.crt references (kcp-root-ca.crt vs kube-root-ca.crt)
+	// and the serviceaccount reference.
+	serviceAccountVolume := corev1.Volume{
+		Name: "kcp-api-access",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				DefaultMode: utilspointer.Int32(420),
+				Sources: []corev1.VolumeProjection{
+					{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: desiredSecretName,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "token",
+									Path: "token",
+								},
+								{
+									Key:  "namespace",
+									Path: "namespace",
+								},
+							},
+						},
+					},
+					{
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "kcp-root-ca.crt",
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  "ca.crt",
+									Path: "ca.crt",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Override Envs, resolve downwardAPI FieldRef and add the VolumeMount to all the containers
+	for i := range podTemplate.Spec.Containers {
+		for _, overrideEnv := range overrideEnvs {
+			podTemplate.Spec.Containers[i].Env = updateEnv(podTemplate.Spec.Containers[i].Env, overrideEnv)
+		}
+		podTemplate.Spec.Containers[i].Env = resolveDownwardAPIFieldRefEnv(podTemplate.Spec.Containers[i].Env, obj)
+		podTemplate.Spec.Containers[i].VolumeMounts = updateVolumeMount(podTemplate.Spec.Containers[i].VolumeMounts, serviceAccountMount)
+	}
+
+	// Override Envs, resolve downwardAPI FieldRef and add the VolumeMount to all the Init containers
+	for i := range podTemplate.Spec.InitContainers {
+		for _, overrideEnv := range overrideEnvs {
+			podTemplate.Spec.InitContainers[i].Env = updateEnv(podTemplate.Spec.InitContainers[i].Env, overrideEnv)
+		}
+		podTemplate.Spec.InitContainers[i].Env = resolveDownwardAPIFieldRefEnv(podTemplate.Spec.InitContainers[i].Env, obj)
+		podTemplate.Spec.InitContainers[i].VolumeMounts = updateVolumeMount(podTemplate.Spec.InitContainers[i].VolumeMounts, serviceAccountMount)
+	}
+
+	// Override Envs, resolve downwardAPI FieldRef and add the VolumeMount to all the Ephemeral containers
+	for i := range podTemplate.Spec.EphemeralContainers {
+		for _, overrideEnv := range overrideEnvs {
+			podTemplate.Spec.EphemeralContainers[i].Env = updateEnv(podTemplate.Spec.EphemeralContainers[i].Env, overrideEnv)
+		}
+		podTemplate.Spec.EphemeralContainers[i].Env = resolveDownwardAPIFieldRefEnv(podTemplate.Spec.EphemeralContainers[i].Env, obj)
+		podTemplate.Spec.EphemeralContainers[i].VolumeMounts = updateVolumeMount(podTemplate.Spec.EphemeralContainers[i].VolumeMounts, serviceAccountMount)
+	}
+
+	// Add the ServiceAccount volume with our overrides.
+	found := false
+	for i := range podTemplate.Spec.Volumes {
+		if podTemplate.Spec.Volumes[i].Name == "kcp-api-access" {
+			podTemplate.Spec.Volumes[i] = serviceAccountVolume
+			found = true
+		}
+	}
+	if !found {
+		podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, serviceAccountVolume)
+	}
+
+	// Overrides DNS to point to the workspace DNS
+	dnsIP, err := dm.getDNSIPForWorkspace(upstreamLogicalName)
+	if err != nil {
+		// the DNS nameserver is not ready yet or other transient failure
+		return err // retry
+	}
+
+	podTemplate.Spec.DNSPolicy = corev1.DNSNone
+	podTemplate.Spec.DNSConfig = &corev1.PodDNSConfig{
+		Nameservers: []string{dnsIP},
+		Searches: []string{ // TODO(LV): from /etc/resolv.conf
+			obj.GetNamespace() + ".svc.cluster.local",
+			"svc.cluster.local",
+			"cluster.local",
+		},
+		Options: []corev1.PodDNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: utilspointer.String("5"),
+			},
+		},
+	}
+
+	if dm.upsyncPods {
+		syncTargetKey := workloadv1alpha1.ToSyncTargetKey(dm.syncTargetClusterName, dm.syncTargetName)
+		labels := podTemplate.Labels
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] = string(workloadv1alpha1.ResourceStateUpsync)
+		labels[workloadv1alpha1.InternalDownstreamClusterLabel] = syncTargetKey
+		podTemplate.Labels = labels
+
+		// TODO(davidfestal): In the future we could add a diff annotation to transform the resource while upsyncing:
+		//   - remove unnecessary fields we don't want leaking to upstream
+		//   - add an owner reference to the upstream deployment
+	}
+
+	newPodTemplateUnstr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(podTemplate)
+	if err != nil {
+		return err
+	}
+
+	// Set the changes back into the obj.
+	return unstructured.SetNestedMap(obj.Object, newPodTemplateUnstr, "spec", "template")
+}
+
+func (dm *PodSpecableMutator) getDNSIPForWorkspace(workspace logicalcluster.Name) (string, error) {
+	// Retrieve the DNS IP associated to the workspace
+	dnsServiceName := shared.GetDNSID(workspace, dm.syncTargetUID, dm.syncTargetName)
+
+	svc, err := dm.serviceLister.Services(dm.dnsNamespace).Get(dnsServiceName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get DNS service: %w", err)
+	}
+
+	ip := svc.Spec.ClusterIP
+	if ip == "" {
+		// not available (yet)
+		return "", fmt.Errorf("DNS service IP address not found")
+	}
+
+	return ip, nil
+}
+
+// resolveDownwardAPIFieldRefEnv replaces the downwardAPI FieldRef EnvVars with the value from the deployment, right now it only replaces the metadata.namespace.
+func resolveDownwardAPIFieldRefEnv(envs []corev1.EnvVar, podspecable *unstructured.Unstructured) []corev1.EnvVar {
+	var result []corev1.EnvVar
+	for _, env := range envs {
+		if env.ValueFrom != nil && env.ValueFrom.FieldRef != nil && env.ValueFrom.FieldRef.FieldPath == "metadata.namespace" {
+			result = append(result, corev1.EnvVar{
+				Name:  env.Name,
+				Value: podspecable.GetNamespace(),
+			})
+		} else {
+			result = append(result, env)
+		}
+	}
+	return result
+}
+
+// findEnv finds an env in a list of envs.
+func findEnv(envs []corev1.EnvVar, name string) (bool, int) {
+	for i := range envs {
+		if envs[i].Name == name {
+			return true, i
+		}
+	}
+	return false, 0
+}
+
+// updateEnv updates an env from a list of envs.
+func updateEnv(envs []corev1.EnvVar, overrideEnv corev1.EnvVar) []corev1.EnvVar {
+	found, i := findEnv(envs, overrideEnv.Name)
+	if found {
+		envs[i].Value = overrideEnv.Value
+	} else {
+		envs = append(envs, overrideEnv)
+	}
+
+	return envs
+}
+
+// findVolumeMount finds a volume mount in a list of volume mounts.
+func findVolumeMount(volumeMounts []corev1.VolumeMount, name string) (bool, int) {
+	for i := range volumeMounts {
+		if volumeMounts[i].Name == name {
+			return true, i
+		}
+	}
+	return false, 0
+}
+
+// updateVolumeMount updates a volume mount from a list of volume mounts.
+func updateVolumeMount(volumeMounts []corev1.VolumeMount, overrideVolumeMount corev1.VolumeMount) []corev1.VolumeMount {
+	found, i := findVolumeMount(volumeMounts, overrideVolumeMount.Name)
+	if found {
+		volumeMounts[i] = overrideVolumeMount
+	} else {
+		volumeMounts = append(volumeMounts, overrideVolumeMount)
+	}
+
+	return volumeMounts
+}

--- a/pkg/syncer/spec/mutators/podspecable_test.go
+++ b/pkg/syncer/spec/mutators/podspecable_test.go
@@ -1,0 +1,1005 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	utilspointer "k8s.io/utils/pointer"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var kcpApiAccessVolume = corev1.Volume{
+	Name: "kcp-api-access",
+	VolumeSource: corev1.VolumeSource{
+		Projected: &corev1.ProjectedVolumeSource{
+			DefaultMode: utilspointer.Int32(420),
+			Sources: []corev1.VolumeProjection{
+				{
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "kcp-default-token-1234",
+						},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "token",
+								Path: "token",
+							},
+							{
+								Key:  "namespace",
+								Path: "namespace",
+							},
+						},
+					},
+				},
+				{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "kcp-root-ca.crt",
+						},
+						Items: []corev1.KeyToPath{
+							{
+								Key:  "ca.crt",
+								Path: "ca.crt",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var kcpApiAccessVolumeMount = corev1.VolumeMount{
+	Name:      "kcp-api-access",
+	MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+	ReadOnly:  true,
+}
+
+func TestDeploymentMutate(t *testing.T) {
+	for _, c := range []struct {
+		desc                                   string
+		upstreamSecrets                        []*corev1.Secret
+		originalDeployment, expectedDeployment *appsv1.Deployment
+		config                                 *rest.Config
+		upsyncPods                             bool
+	}{{
+		desc: "Deployment without Envs or volumes is mutated.",
+		upstreamSecrets: []*corev1.Secret{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-token-1234",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey:         "root:default:testing",
+						"kubernetes.io/service-account.name": "default",
+					},
+				},
+				Data: map[string][]byte{
+					"token":     []byte("token"),
+					"namespace": []byte("namespace"),
+				},
+			},
+		},
+		originalDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: utilspointer.Bool(false),
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "KUBERNETES_SERVICE_PORT",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_HOST",
+										Value: "4.5.6.7",
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									kcpApiAccessVolumeMount,
+								},
+							},
+						},
+						DNSPolicy: corev1.DNSNone,
+						DNSConfig: &corev1.PodDNSConfig{
+							Nameservers: []string{"8.8.8.8"},
+							Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+							Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+						},
+						Volumes: []corev1.Volume{
+							kcpApiAccessVolume,
+						},
+					},
+				},
+			},
+		},
+		config: &rest.Config{
+			Host: "https://4.5.6.7:12345",
+		},
+	}, {
+		desc:       "Deployment without Envs or volumes is mutated, with pod-related changes if pod upsyncing is on.",
+		upsyncPods: true,
+		upstreamSecrets: []*corev1.Secret{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-token-1234",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey:         "root:default:testing",
+						"kubernetes.io/service-account.name": "default",
+					},
+				},
+				Data: map[string][]byte{
+					"token":     []byte("token"),
+					"namespace": []byte("namespace"),
+				},
+			},
+		},
+		originalDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"state.workload.kcp.io/" + workloadv1alpha1.ToSyncTargetKey(logicalcluster.Name("root:default:testing"), "syncTargetName"): "Upsync",
+							"internal.workload.kcp.io/cluster": workloadv1alpha1.ToSyncTargetKey(logicalcluster.Name("root:default:testing"), "syncTargetName"),
+						},
+					},
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: utilspointer.Bool(false),
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "KUBERNETES_SERVICE_PORT",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_HOST",
+										Value: "4.5.6.7",
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									kcpApiAccessVolumeMount,
+								},
+							},
+						},
+						DNSPolicy: corev1.DNSNone,
+						DNSConfig: &corev1.PodDNSConfig{
+							Nameservers: []string{"8.8.8.8"},
+							Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+							Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+						},
+						Volumes: []corev1.Volume{
+							kcpApiAccessVolume,
+						},
+					},
+				},
+			},
+		},
+		config: &rest.Config{
+			Host: "https://4.5.6.7:12345",
+		},
+	}, {
+		desc: "Deployment with one env var gets mutated but the already existing env var remains the same",
+		upstreamSecrets: []*corev1.Secret{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-token-1234",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey:         "root:default:testing",
+						"kubernetes.io/service-account.name": "default",
+					},
+				},
+				Data: map[string][]byte{
+					"token":     []byte("token"),
+					"namespace": []byte("namespace"),
+				},
+			},
+		},
+		originalDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "TEST_ENV_VAR",
+										Value: "test-value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedDeployment: &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "namespace",
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root:default:testing",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: new(int32),
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: utilspointer.Bool(false),
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "test-image",
+								Env: []corev1.EnvVar{
+									{
+										Name:  "TEST_ENV_VAR",
+										Value: "test-value",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_PORT",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+										Value: "12345",
+									},
+									{
+										Name:  "KUBERNETES_SERVICE_HOST",
+										Value: "4.5.6.7",
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									kcpApiAccessVolumeMount,
+								},
+							},
+						},
+						DNSPolicy: corev1.DNSNone,
+						DNSConfig: &corev1.PodDNSConfig{
+							Nameservers: []string{"8.8.8.8"},
+							Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+							Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+						},
+						Volumes: []corev1.Volume{
+							kcpApiAccessVolume,
+						},
+					},
+				},
+			},
+		},
+		config: &rest.Config{
+			Host: "https://4.5.6.7:12345",
+		},
+	},
+		{desc: "Deployment with an env var named KUBERNETES_SERVICE_PORT gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-token-1234",
+						Namespace: "namespace",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey:         "root:default:testing",
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
+			originalDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "99999",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							AutomountServiceAccountToken: utilspointer.Bool(false),
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_HOST",
+											Value: "4.5.6.7",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										kcpApiAccessVolumeMount,
+									},
+								},
+							},
+							DNSPolicy: corev1.DNSNone,
+							DNSConfig: &corev1.PodDNSConfig{
+								Nameservers: []string{"8.8.8.8"},
+								Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+								Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+							},
+							Volumes: []corev1.Volume{
+								kcpApiAccessVolume,
+							},
+						},
+					},
+				},
+			},
+			config: &rest.Config{
+				Host: "https://4.5.6.7:12345",
+			}},
+		{desc: "Deployment with an existing VolumeMount named kcp-api-access gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-token-1234",
+						Namespace: "namespace",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey:         "root:default:testing",
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
+			originalDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "99999",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "kcp-api-access",
+											MountPath: "totally-incorrect-path",
+											ReadOnly:  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							AutomountServiceAccountToken: utilspointer.Bool(false),
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_HOST",
+											Value: "4.5.6.7",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										kcpApiAccessVolumeMount,
+									},
+								},
+							},
+							DNSPolicy: corev1.DNSNone,
+							DNSConfig: &corev1.PodDNSConfig{
+								Nameservers: []string{"8.8.8.8"},
+								Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+								Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+							},
+							Volumes: []corev1.Volume{
+								kcpApiAccessVolume,
+							},
+						},
+					},
+				},
+			},
+			config: &rest.Config{
+				Host: "https://4.5.6.7:12345",
+			}},
+		{desc: "Deployment with an existing Volume named kcp-api-access gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-token-1234",
+						Namespace: "namespace",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey:         "root:default:testing",
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
+			originalDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "99999",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "kcp-api-access",
+											MountPath: "totally-not-the-path",
+											ReadOnly:  false,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "kcp-api-access",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "this-is-not-the-secret-you-are-looking-for",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							AutomountServiceAccountToken: utilspointer.Bool(false),
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_HOST",
+											Value: "4.5.6.7",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										kcpApiAccessVolumeMount,
+									},
+								},
+							},
+							DNSPolicy: corev1.DNSNone,
+							DNSConfig: &corev1.PodDNSConfig{
+								Nameservers: []string{"8.8.8.8"},
+								Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+								Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+							},
+							Volumes: []corev1.Volume{
+								kcpApiAccessVolume,
+							},
+						},
+					},
+				},
+			},
+			config: &rest.Config{
+				Host: "https://4.5.6.7:12345",
+			}},
+		{desc: "Deployment with an EnvVar value coming from the DownwardAPI,only the metadata.namespace should be made static",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "default-token-1234",
+						Namespace: "namespace",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey:         "root:default:testing",
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
+			originalDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name: "DOWNWARDAPI_ENV_NAMESPACE",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.namespace",
+												},
+											},
+										},
+										{
+											Name: "DOWNWARDAPI_ENV_NAME",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.name",
+												},
+											},
+										},
+										{
+											Name:  "MYENV",
+											Value: "myenv",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "namespace",
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: "root:default:testing",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: new(int32),
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							AutomountServiceAccountToken: utilspointer.Bool(false),
+							Containers: []corev1.Container{
+								{
+									Name:  "test-container",
+									Image: "test-image",
+									Env: []corev1.EnvVar{
+										{
+											Name:  "DOWNWARDAPI_ENV_NAMESPACE",
+											Value: "namespace",
+										},
+										{
+											Name: "DOWNWARDAPI_ENV_NAME",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "metadata.name",
+												},
+											},
+										},
+										{
+											Name:  "MYENV",
+											Value: "myenv",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_PORT",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_PORT_HTTPS",
+											Value: "12345",
+										},
+										{
+											Name:  "KUBERNETES_SERVICE_HOST",
+											Value: "4.5.6.7",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										kcpApiAccessVolumeMount,
+									},
+								},
+							},
+							DNSPolicy: corev1.DNSNone,
+							DNSConfig: &corev1.PodDNSConfig{
+								Nameservers: []string{"8.8.8.8"},
+								Searches:    []string{"namespace.svc.cluster.local", "svc.cluster.local", "cluster.local"},
+								Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: utilspointer.String("5")}},
+							},
+							Volumes: []corev1.Volume{
+								kcpApiAccessVolume,
+							},
+						},
+					},
+				},
+			},
+			config: &rest.Config{
+				Host: "https://4.5.6.7:12345",
+			}},
+	} {
+		{
+			t.Run(c.desc, func(t *testing.T) {
+				secretLister := func(upstreamLogicalCluster logicalcluster.Name, namespace string) ([]runtime.Object, error) {
+					unstructuredObjects := make([]runtime.Object, 0, len(c.upstreamSecrets))
+					for _, obj := range c.upstreamSecrets {
+						unstObj, err := toUnstructured(obj)
+						require.NoError(t, err)
+						unstructuredObjects = append(unstructuredObjects, unstObj)
+					}
+					return unstructuredObjects, nil
+				}
+
+				clusterName := logicalcluster.Name("root:default:testing")
+
+				serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+				dnsServiceName := shared.GetDNSID(clusterName, "syncTargetUID", "syncTargetName")
+				err := serviceIndexer.Add(service(dnsServiceName, "dnsNamespace"))
+				require.NoError(t, err, "Service Add() = %v", err)
+				svcLister := listerscorev1.NewServiceLister(serviceIndexer)
+
+				dm := &PodSpecableMutator{
+					getWorkspaceURL: func(obj *unstructured.Unstructured) (*url.URL, error) {
+						return url.Parse(c.config.Host)
+					},
+					listSecrets:           secretLister,
+					serviceLister:         svcLister,
+					syncTargetClusterName: clusterName,
+					syncTargetUID:         "syncTargetUID",
+					syncTargetName:        "syncTargetName",
+					dnsNamespace:          "dnsNamespace",
+					upsyncPods:            c.upsyncPods,
+				}
+
+				unstrOriginalDeployment, err := toUnstructured(c.originalDeployment)
+				require.NoError(t, err, "toUnstructured() = %v", err)
+
+				err = dm.Mutate(unstrOriginalDeployment)
+				require.NoError(t, err, "Mutate() = %v", err)
+
+				mutatedOriginalDeployment, err := toDeployment(unstrOriginalDeployment)
+				require.NoError(t, err, "toDeployment() = %v", err)
+
+				if !apiequality.Semantic.DeepEqual(mutatedOriginalDeployment, c.expectedDeployment) {
+					t.Errorf("expected deployments are not equal, got:\n %#v \n wanted:\n %#v \n", c.expectedDeployment, mutatedOriginalDeployment)
+				}
+			})
+		}
+	}
+}
+
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	bs, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("Marshal() = %w", err)
+	}
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(bs, u); err != nil {
+		return nil, fmt.Errorf("Unmarshal() = %w", err)
+	}
+	return u, nil
+}
+
+func toDeployment(obj *unstructured.Unstructured) (*appsv1.Deployment, error) {
+	bs, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("Marshal() = %w", err)
+	}
+	d := &appsv1.Deployment{}
+	if err := json.Unmarshal(bs, d); err != nil {
+		return nil, fmt.Errorf("Unmarshal() = %w", err)
+	}
+	return d, nil
+}
+
+func service(name, namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "8.8.8.8",
+		},
+	}
+}

--- a/pkg/syncer/spec/mutators/secrets.go
+++ b/pkg/syncer/spec/mutators/secrets.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type SecretMutator struct {
+}
+
+func (sm *SecretMutator) GVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		{
+			Group:    "",
+			Version:  "v1",
+			Resource: "secrets",
+		},
+	}
+}
+
+func NewSecretMutator() *SecretMutator {
+	return &SecretMutator{}
+}
+
+// Mutate applies the mutator changes to the object.
+func (sm *SecretMutator) Mutate(obj *unstructured.Unstructured) error {
+	// We need transform the serviceaccount tokens into an Opaque secret, in order to avoid the pcluster to rewrite them,
+	// and we remove the annotations that point to the kcp serviceaccount name/uid.
+	if _, ok := obj.GetAnnotations()[corev1.ServiceAccountNameKey]; ok {
+		obj.Object["type"] = string(corev1.SecretTypeOpaque)
+		annotations := obj.GetAnnotations()
+		delete(annotations, corev1.ServiceAccountNameKey)
+		delete(annotations, corev1.ServiceAccountUIDKey)
+		if len(annotations) == 0 {
+			obj.SetAnnotations(nil)
+		} else {
+			obj.SetAnnotations(annotations)
+		}
+	}
+
+	return nil
+}

--- a/pkg/syncer/spec/mutators/secrets_test.go
+++ b/pkg/syncer/spec/mutators/secrets_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecretsMutate(t *testing.T) {
+	for _, c := range []struct {
+		desc                           string
+		originalSecret, expectedSecret *corev1.Secret
+	}{{
+		desc: "A secret that is not a ServiceAccount token, should not be mutated",
+		originalSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-super-secret-stuff",
+				Annotations: map[string]string{
+					"testing": "testing",
+				},
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		},
+		expectedSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-super-secret-stuff",
+				Annotations: map[string]string{
+					"testing": "testing",
+				},
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		},
+	}, {
+		desc: "A ServiceAccount secret, should be mutated",
+		originalSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-token-f8f8f8",
+				Annotations: map[string]string{
+					"kubernetes.io/service-account.name": "default",
+					"kubernetes.io/service-account.uid":  "asdasdasdasdasdsadsadas",
+				},
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{
+				"token":     []byte("token"),
+				"namespace": []byte("namespace"),
+			},
+		},
+		expectedSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-token-f8f8f8",
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"token":     []byte("token"),
+				"namespace": []byte("namespace"),
+			},
+		},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			sm := SecretMutator{}
+			unstrOriginalSecret, err := toUnstructured(c.originalSecret)
+			require.NoError(t, err)
+			unstrExpectedSecret, err := toUnstructured(c.expectedSecret)
+			require.NoError(t, err)
+			// The Secret mutator doesn't use the logical cluster.
+			err = sm.Mutate(unstrOriginalSecret)
+			require.NoError(t, err)
+			if !apiequality.Semantic.DeepEqual(unstrOriginalSecret, unstrExpectedSecret) {
+				t.Errorf("secret mutated incorrectly, got: %v expected: %v", unstrOriginalSecret.Object, unstrExpectedSecret.Object)
+			}
+		})
+	}
+}

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	syncerindexers "github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec/dns"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+const (
+	controllerName = "kcp-workload-syncer-spec"
+)
+
+var namespaceGVR schema.GroupVersionResource = corev1.SchemeGroupVersion.WithResource("namespaces")
+
+type Mutator interface {
+	GVRs() []schema.GroupVersionResource
+	Mutate(obj *unstructured.Unstructured) error
+}
+
+type Controller struct {
+	queue workqueue.RateLimitingInterface
+
+	mutators     map[schema.GroupVersionResource]Mutator
+	dnsProcessor *dns.DNSProcessor
+
+	getUpstreamClient func(clusterName logicalcluster.Name) (dynamic.Interface, error)
+	downstreamClient  dynamic.Interface
+
+	getUpstreamLister                 func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	getDownstreamLister               func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	listDownstreamNamespacesByLocator func(jsonLocator string) ([]*unstructured.Unstructured, error)
+
+	downstreamNSCleaner       shared.Cleaner
+	syncTargetName            string
+	syncTargetClusterName     logicalcluster.Name
+	syncTargetUID             types.UID
+	syncTargetKey             string
+	advancedSchedulingEnabled bool
+}
+
+func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name, syncTargetName, syncTargetKey string,
+	advancedSchedulingEnabled bool,
+	upstreamClient kcpdynamic.ClusterInterface, downstreamClient dynamic.Interface, downstreamKubeClient kubernetes.Interface,
+	ddsifForUpstreamSyncer *ddsif.DiscoveringDynamicSharedInformerFactory,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	downstreamNSCleaner shared.Cleaner,
+	syncTargetUID types.UID,
+	dnsNamespace string,
+	dnsProcessor *dns.DNSProcessor,
+	dnsImage string,
+	mutators ...Mutator) (*Controller, error) {
+	c := Controller{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+
+		getUpstreamClient: func(clusterName logicalcluster.Name) (dynamic.Interface, error) {
+			return upstreamClient.Cluster(clusterName.Path()), nil
+		},
+		downstreamClient:    downstreamClient,
+		downstreamNSCleaner: downstreamNSCleaner,
+
+		getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			return informer.Lister(), nil
+		},
+		getUpstreamLister: func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			informers, notSynced := ddsifForUpstreamSyncer.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the upstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the upstream informer factory", gvr)
+			}
+			return informer.Lister().ByCluster(clusterName), nil
+		},
+
+		listDownstreamNamespacesByLocator: func(jsonLocator string) ([]*unstructured.Unstructured, error) {
+			nsInformer, err := ddsifForDownstream.ForResource(namespaceGVR)
+			if err != nil {
+				return nil, err
+			}
+			return indexers.ByIndex[*unstructured.Unstructured](nsInformer.Informer().GetIndexer(), syncerindexers.ByNamespaceLocatorIndexName, jsonLocator)
+		},
+		syncTargetName:            syncTargetName,
+		syncTargetClusterName:     syncTargetClusterName,
+		syncTargetUID:             syncTargetUID,
+		syncTargetKey:             syncTargetKey,
+		advancedSchedulingEnabled: advancedSchedulingEnabled,
+
+		mutators:     make(map[schema.GroupVersionResource]Mutator, 2),
+		dnsProcessor: dnsProcessor,
+	}
+
+	for _, mutator := range mutators {
+		for _, gvr := range mutator.GVRs() {
+			c.mutators[gvr] = mutator
+		}
+	}
+
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	namespaceGVR := corev1.SchemeGroupVersion.WithResource("namespaces")
+
+	ddsifForUpstreamSyncer.AddEventHandler(
+		ddsif.GVREventHandlerFuncs{
+			AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				c.AddToQueue(gvr, obj, logger)
+			},
+			UpdateFunc: func(gvr schema.GroupVersionResource, oldObj, newObj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				oldUnstrob := oldObj.(*unstructured.Unstructured)
+				newUnstrob := newObj.(*unstructured.Unstructured)
+
+				if !deepEqualApartFromStatus(logger, oldUnstrob, newUnstrob) {
+					c.AddToQueue(gvr, newUnstrob, logger)
+				}
+			},
+			DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				c.AddToQueue(gvr, obj, logger)
+			},
+		},
+	)
+
+	return &c, nil
+}
+
+func NewSpecSyncerForDownstream(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name, syncTargetName, syncTargetKey string,
+	advancedSchedulingEnabled bool,
+	getShardAccess synctarget.GetShardAccessFunc,
+	downstreamClient dynamic.Interface, downstreamKubeClient kubernetes.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	downstreamNSCleaner shared.Cleaner,
+	syncTargetUID types.UID,
+	dnsNamespace string,
+	dnsProcessor *dns.DNSProcessor,
+	dnsImage string,
+	mutators ...Mutator) (*Controller, error) {
+	c := Controller{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+
+		getUpstreamClient: func(clusterName logicalcluster.Name) (dynamic.Interface, error) {
+			shardAccess, ok, err := getShardAccess(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+			return shardAccess.SyncerClient.Cluster(clusterName.Path()), nil
+		},
+		downstreamClient:    downstreamClient,
+		downstreamNSCleaner: downstreamNSCleaner,
+
+		getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			return informer.Lister(), nil
+		},
+		getUpstreamLister: func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			shardAccess, ok, err := getShardAccess(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+
+			informers, notSynced := shardAccess.SyncerDDSIF.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the upstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the upstream informer factory", gvr)
+			}
+			return informer.Lister().ByCluster(clusterName), nil
+		},
+
+		listDownstreamNamespacesByLocator: func(jsonLocator string) ([]*unstructured.Unstructured, error) {
+			nsInformer, err := ddsifForDownstream.ForResource(namespaceGVR)
+			if err != nil {
+				return nil, err
+			}
+			return indexers.ByIndex[*unstructured.Unstructured](nsInformer.Informer().GetIndexer(), syncerindexers.ByNamespaceLocatorIndexName, jsonLocator)
+		},
+		syncTargetName:            syncTargetName,
+		syncTargetClusterName:     syncTargetClusterName,
+		syncTargetUID:             syncTargetUID,
+		syncTargetKey:             syncTargetKey,
+		advancedSchedulingEnabled: advancedSchedulingEnabled,
+
+		mutators: make(map[schema.GroupVersionResource]Mutator, 2),
+
+		dnsProcessor: dnsProcessor,
+	}
+
+	for _, mutator := range mutators {
+		for _, gvr := range mutator.GVRs() {
+			c.mutators[gvr] = mutator
+		}
+	}
+
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	namespaceGVR := corev1.SchemeGroupVersion.WithResource("namespaces")
+
+	ddsifForDownstream.AddEventHandler(ddsif.GVREventHandlerFuncs{
+		DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if gvr == namespaceGVR {
+				return
+			}
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+			unstrObj, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", unstrObj))
+				return
+			}
+			if unstrObj.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+				return
+			}
+
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("error getting key for type %T: %w", obj, err))
+				return
+			}
+			namespace, name, err := cache.SplitMetaNamespaceKey(key)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("error splitting key %q: %w", key, err))
+			}
+			logger := logging.WithQueueKey(logger, key).WithValues("gvr", gvr, DownstreamNamespace, namespace, DownstreamName, name)
+			logger.V(3).Info("processing delete event")
+
+			var nsLocatorHolder *unstructured.Unstructured
+			// Handle namespaced resources
+			if namespace != "" {
+				// Use namespace lister
+				namespaceLister, err := c.getDownstreamLister(namespaceGVR)
+				if err != nil {
+					utilruntime.HandleError(err)
+					return
+				}
+
+				nsObj, err := namespaceLister.Get(namespace)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				if err != nil {
+					utilruntime.HandleError(err)
+					return
+				}
+				c.downstreamNSCleaner.PlanCleaning(namespace)
+				nsLocatorHolder, ok = nsObj.(*unstructured.Unstructured)
+				if !ok {
+					utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", nsObj))
+					return
+				}
+			} else {
+				// The nsLocatorHolder is in the resource itself for cluster-scoped resources.
+				nsLocatorHolder = unstrObj
+			}
+			logger = logging.WithObject(logger, nsLocatorHolder)
+
+			locator, ok := nsLocatorHolder.GetAnnotations()[shared.NamespaceLocatorAnnotation]
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("unable to find the locator annotation in resource %s", nsLocatorHolder.GetName()))
+				return
+			}
+			nsLocator := &shared.NamespaceLocator{}
+			err = json.Unmarshal([]byte(locator), nsLocator)
+			if err != nil {
+				utilruntime.HandleError(err)
+				return
+			}
+			logger.V(4).Info("found", "NamespaceLocator", nsLocator)
+			m := &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: nsLocator.ClusterName.String(),
+				},
+				Namespace: nsLocator.Namespace,
+				Name:      shared.GetUpstreamResourceName(gvr, name),
+			}
+			c.AddToQueue(gvr, m, logger)
+		},
+	})
+
+	return &c, nil
+}
+
+type queueKey struct {
+	gvr schema.GroupVersionResource
+	key string // meta namespace key
+}
+
+func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}, logger logr.Logger) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(2).Info("queueing GVR", "gvr", gvr.String())
+	c.queue.Add(
+		queueKey{
+			gvr: gvr,
+			key: key,
+		},
+	)
+}
+
+// Start starts N worker processes processing work items.
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting syncer workers")
+	defer logger.Info("Stopping syncer workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	qk := key.(queueKey)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), qk.key).WithValues("gvr", qk.gvr)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if retryAfter, err := c.process(ctx, qk.gvr, qk.key); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if retryAfter != nil {
+		c.queue.AddAfter(key, *retryAfter)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -1,0 +1,571 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+const (
+	syncerApplyManager = "syncer"
+)
+
+func deepEqualApartFromStatus(logger logr.Logger, oldUnstrob, newUnstrob *unstructured.Unstructured) bool {
+	// TODO(jmprusi): Remove this after switching to virtual workspaces.
+	// remove status annotation from oldObj and newObj before comparing
+	oldAnnotations, _, err := unstructured.NestedStringMap(oldUnstrob.Object, "metadata", "annotations")
+	if err != nil {
+		logger.Error(err, "failed to get annotations from object")
+		return false
+	}
+	for k := range oldAnnotations {
+		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterStatusAnnotationPrefix) {
+			delete(oldAnnotations, k)
+		}
+	}
+
+	newAnnotations, _, err := unstructured.NestedStringMap(newUnstrob.Object, "metadata", "annotations")
+	if err != nil {
+		logger.Error(err, "failed to get annotations from object")
+		return false
+	}
+	for k := range newAnnotations {
+		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterStatusAnnotationPrefix) {
+			delete(newAnnotations, k)
+		}
+	}
+
+	if !equality.Semantic.DeepEqual(oldAnnotations, newAnnotations) {
+		return false
+	}
+	if !equality.Semantic.DeepEqual(oldUnstrob.GetLabels(), newUnstrob.GetLabels()) {
+		return false
+	}
+	if !equality.Semantic.DeepEqual(oldUnstrob.GetFinalizers(), newUnstrob.GetFinalizers()) {
+		return false
+	}
+
+	oldIsBeingDeleted := oldUnstrob.GetDeletionTimestamp() != nil
+	newIsBeingDeleted := newUnstrob.GetDeletionTimestamp() != nil
+	if oldIsBeingDeleted != newIsBeingDeleted {
+		return false
+	}
+
+	oldObjKeys := sets.StringKeySet(oldUnstrob.UnstructuredContent())
+	newObjKeys := sets.StringKeySet(newUnstrob.UnstructuredContent())
+	for _, key := range oldObjKeys.Union(newObjKeys).UnsortedList() {
+		if key == "metadata" || key == "status" {
+			continue
+		}
+		if !equality.Semantic.DeepEqual(oldUnstrob.UnstructuredContent()[key], newUnstrob.UnstructuredContent()[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string) (retryAfter *time.Duration, err error) {
+	logger := klog.FromContext(ctx)
+
+	// from upstream
+	clusterName, upstreamNamespace, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "Invalid key")
+		return nil, nil
+	}
+	logger = logger.WithValues(logging.WorkspaceKey, clusterName, logging.NamespaceKey, upstreamNamespace, logging.NameKey, name)
+
+	desiredNSLocator := shared.NewNamespaceLocator(clusterName, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
+	jsonNSLocator, err := json.Marshal(desiredNSLocator)
+	if err != nil {
+		return nil, err
+	}
+
+	var downstreamNamespace string
+	// Only look for the downstream namespace if the resource is namespaced, avoid in case of cluster-scoped.
+	if upstreamNamespace != "" {
+		downstreamNamespaces, err := c.listDownstreamNamespacesByLocator(string(jsonNSLocator))
+		if err != nil {
+			return nil, err
+		}
+
+		if len(downstreamNamespaces) == 1 {
+			namespace := downstreamNamespaces[0]
+			logger.WithValues(DownstreamName, namespace.GetName()).V(4).Info("Found downstream namespace for upstream namespace")
+			downstreamNamespace = namespace.GetName()
+		} else if len(downstreamNamespaces) > 1 {
+			// This should never happen unless there's some namespace collision.
+			var namespacesCollisions []string
+			for _, namespace := range downstreamNamespaces {
+				namespacesCollisions = append(namespacesCollisions, namespace.GetName())
+			}
+			return nil, fmt.Errorf("(namespace collision) found multiple downstream namespaces: %s for upstream namespace %s|%s", strings.Join(namespacesCollisions, ","), clusterName, upstreamNamespace)
+		} else {
+			logger.V(4).Info("No downstream namespaces found")
+			downstreamNamespace, err = shared.PhysicalClusterNamespaceName(desiredNSLocator)
+			if err != nil {
+				logger.Error(err, "Error hashing namespace")
+				return nil, nil
+			}
+		}
+	}
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace)
+
+	// get the upstream object
+	upstreamSyncerLister, err := c.getUpstreamLister(clusterName, gvr)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := upstreamSyncerLister.ByNamespace(upstreamNamespace).Get(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if apierrors.IsNotFound(err) {
+		// deleted upstream => delete downstream
+		logger.Info("Deleting downstream object for upstream object")
+		if downstreamNamespace != "" {
+			err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+		} else {
+			err = c.downstreamClient.Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
+		}
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		// If the resource is namespaced, let's plan the cleanup of it's namespace.
+		if downstreamNamespace != "" {
+			c.downstreamNSCleaner.PlanCleaning(downstreamNamespace)
+		}
+		return nil, nil
+	}
+
+	// upsert downstream
+	upstreamObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("object to synchronize is expected to be Unstructured, but is %T", obj)
+	}
+
+	if actualVersion := upstreamObj.GetAnnotations()[handlers.KCPOriginalAPIVersionAnnotation]; actualVersion != "" {
+		actualGV, err := schema.ParseGroupVersion(actualVersion)
+		if err != nil {
+			logger.Error(err, "error parsing original API version annotation", "annotation", actualVersion)
+			// Returning an error and reprocessing will presumably result in the same parse error, so just return
+			// nil here.
+			return nil, nil
+		}
+		gvr.Version = actualGV.Version
+		logger.V(4).Info("using actual API version from annotation", "actual", actualVersion)
+	}
+
+	if downstreamNamespace != "" {
+		if err := c.ensureDownstreamNamespaceExists(ctx, downstreamNamespace, upstreamObj); err != nil {
+			return nil, err
+		}
+	} else {
+		// In cluser-wide resources we also need to check for possible collisions, as the resource could exist in the pcluster but now owned by this workspace.
+		// TODO(jmprusi): We should indicate the collision somehow (condition/annotation?) to avoid retrying the resource over and over.
+		if err := c.clusterWideCollisionCheck(ctx, gvr, upstreamObj); err != nil {
+			return nil, err
+		}
+	}
+
+	deploymentGVR := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
+
+	// Make sure the DNS nameserver for the current workspace is up and running
+	if dnsUpAndReady, err := c.dnsProcessor.EnsureDNSUpAndReady(ctx, desiredNSLocator); err != nil {
+		logger.Error(err, "failed to check DNS nameserver is up and running (retrying)")
+		return nil, err
+	} else if !dnsUpAndReady && gvr == deploymentGVR {
+		logger.Info("DNS Server is not ready for the deployment resource to sync: requeue the deployment in 500ms")
+		retryDelay := 500 * time.Millisecond
+		return &retryDelay, nil
+	}
+
+	if added, err := c.ensureSyncerFinalizer(ctx, gvr, upstreamObj); added {
+		// The successful update of the upstream resource finalizer will trigger a new reconcile
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return nil, c.applyToDownstream(ctx, gvr, downstreamNamespace, upstreamObj)
+}
+
+// TODO: This function is there as a quick and dirty implementation of namespace creation.
+//
+//	In fact We should also be getting notifications about namespaces created upstream and be creating downstream equivalents.
+func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downstreamNamespace string, upstreamObj *unstructured.Unstructured) error {
+	logger := klog.FromContext(ctx)
+
+	// If the namespace was marked for deletion, let's cancel it, as we expect to use it.
+	c.downstreamNSCleaner.CancelCleaning(downstreamNamespace)
+
+	namespaces := c.downstreamClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	})
+
+	newNamespace := &unstructured.Unstructured{}
+	newNamespace.SetAPIVersion("v1")
+	newNamespace.SetKind("Namespace")
+	newNamespace.SetName(downstreamNamespace)
+
+	// TODO: if the downstream namespace loses these annotations/labels after creation,
+	// we don't have anything in place currently that will put them back.
+	upstreamLogicalCluster := logicalcluster.From(upstreamObj)
+	desiredNSLocator := shared.NewNamespaceLocator(upstreamLogicalCluster, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamObj.GetNamespace())
+	b, err := json.Marshal(desiredNSLocator)
+	if err != nil {
+		return err
+	}
+	newNamespace.SetAnnotations(map[string]string{
+		shared.NamespaceLocatorAnnotation: string(b),
+	})
+
+	desiredTenantID, err := shared.GetTenantID(desiredNSLocator)
+	if err != nil {
+		return err
+	}
+
+	newNamespace.SetLabels(map[string]string{
+		// TODO: this should be set once at syncer startup and propagated around everywhere.
+		workloadv1alpha1.InternalDownstreamClusterLabel: c.syncTargetKey,
+		shared.TenantIDLabel:                            desiredTenantID,
+	})
+
+	namespaceLister, err := c.getDownstreamLister(namespaceGVR)
+	if err != nil {
+		return err
+	}
+
+	// Check if the namespace already exists, if not create it.
+	namespace, err := namespaceLister.Get(newNamespace.GetName())
+	if apierrors.IsNotFound(err) {
+		_, err = namespaces.Create(ctx, newNamespace, metav1.CreateOptions{})
+		if err == nil {
+			logger.Info("Created downstream namespace for upstream namespace")
+			return nil
+		}
+	}
+	if apierrors.IsAlreadyExists(err) {
+		namespace, err = namespaces.Get(ctx, newNamespace.GetName(), metav1.GetOptions{})
+	}
+	if err != nil {
+		return err
+	}
+
+	// The namespace exists, so check if it has the correct namespace locator.
+	unstrNamespace := namespace.(*unstructured.Unstructured)
+	nsLocator, exists, err := shared.LocatorFromAnnotations(unstrNamespace.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("(possible namespace collision) namespace %s already exists, but found an error when trying to decode the annotation: %w", newNamespace.GetName(), err)
+	}
+	if !exists {
+		return fmt.Errorf("(namespace collision) namespace %s has no namespace locator", unstrNamespace.GetName())
+	}
+	if !reflect.DeepEqual(desiredNSLocator, *nsLocator) {
+		return fmt.Errorf("(namespace collision) namespace %s already exists, but has a different namespace locator annotation: %+v vs %+v", newNamespace.GetName(), nsLocator, desiredNSLocator)
+	}
+
+	// Handle kcp upgrades by checking the tenant ID is set and correct
+	if tenantID, ok := unstrNamespace.GetLabels()[shared.TenantIDLabel]; !ok || tenantID != desiredTenantID {
+		labels := unstrNamespace.GetLabels()
+		labels[shared.TenantIDLabel] = desiredTenantID
+		unstrNamespace.SetLabels(labels)
+		_, err := namespaces.Update(ctx, unstrNamespace, metav1.UpdateOptions{})
+		return err
+	}
+
+	return nil
+}
+
+// TODO(jmprusi): merge with ensureDownstreamNamespaceExists and make it more generic.
+func (c *Controller) clusterWideCollisionCheck(ctx context.Context, gvr schema.GroupVersionResource, upstreamObj *unstructured.Unstructured) error {
+	// Check if the resource already exists, if so check if it has the correct namespace locator.
+	downstreamLister, err := c.getDownstreamLister(gvr)
+	if err != nil {
+		return err
+	}
+	resource, err := downstreamLister.Get(upstreamObj.GetName())
+	if apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// The resource exists, so check if it has the correct namespace locator.
+	unstrResource := resource.(*unstructured.Unstructured)
+	nsLocator, exists, err := shared.LocatorFromAnnotations(unstrResource.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("(possible cluster-wide resource collision) resource %s already exists, but found an error when trying to decode the annotation: %w", unstrResource.GetName(), err)
+	}
+	if !exists {
+		return fmt.Errorf("(cluster-wide resource collision) resource %s has no namespace locator", unstrResource.GetName())
+	}
+	if nsLocator.ClusterName != c.syncTargetClusterName {
+		return fmt.Errorf("(cluster-wide resource collision) resource %s already exists, but has a different namespace locator annotation: %+v", unstrResource.GetName(), nsLocator)
+	}
+
+	return nil
+}
+
+func (c *Controller) ensureSyncerFinalizer(ctx context.Context, gvr schema.GroupVersionResource, upstreamObj *unstructured.Unstructured) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	upstreamFinalizers := upstreamObj.GetFinalizers()
+	hasFinalizer := false
+	for _, finalizer := range upstreamFinalizers {
+		if finalizer == shared.SyncerFinalizerNamePrefix+c.syncTargetKey {
+			hasFinalizer = true
+		}
+	}
+
+	// TODO(davidfestal): When using syncer virtual workspace we would check the DeletionTimestamp on the upstream object, instead of the DeletionTimestamp annotation,
+	// as the virtual workspace will set the deletionTimestamp() on the location view by a transformation.
+	intendedToBeRemovedFromLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+c.syncTargetKey] != ""
+
+	// TODO(davidfestal): When using syncer virtual workspace this condition would not be necessary anymore, since directly tested on the virtual workspace side.
+	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterFinalizerAnnotationPrefix+c.syncTargetKey] != ""
+
+	if !hasFinalizer && (!intendedToBeRemovedFromLocation || stillOwnedByExternalActorForLocation) {
+		upstreamObjCopy := upstreamObj.DeepCopy()
+		namespace := upstreamObjCopy.GetNamespace()
+		clusterName := logicalcluster.From(upstreamObjCopy)
+
+		upstreamFinalizers = append(upstreamFinalizers, shared.SyncerFinalizerNamePrefix+c.syncTargetKey)
+		upstreamObjCopy.SetFinalizers(upstreamFinalizers)
+		upstreamClient, err := c.getUpstreamClient(clusterName)
+		if err != nil {
+			return false, err
+		}
+		if _, err := upstreamClient.Resource(gvr).Namespace(namespace).Update(ctx, upstreamObjCopy, metav1.UpdateOptions{}); err != nil {
+			logger.Error(err, "Failed adding finalizer on upstream upstreamresource")
+			return false, err
+		}
+		logger.Info("Updated upstream resource with syncer finalizer")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVersionResource, downstreamNamespace string, upstreamObj *unstructured.Unstructured) error {
+	logger := klog.FromContext(ctx)
+
+	upstreamObjLogicalCluster := logicalcluster.From(upstreamObj)
+	downstreamObj := upstreamObj.DeepCopy()
+
+	// Run name transformations on the downstreamObj.
+	transformedName := getTransformedName(downstreamObj)
+
+	// TODO(jmprusi): When using syncer virtual workspace we would check the DeletionTimestamp on the upstream object, instead of the DeletionTimestamp annotation,
+	// as the virtual workspace will set the deletionTimestamp() on the location view by a transformation.
+	intendedToBeRemovedFromLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+c.syncTargetKey] != ""
+
+	// TODO(jmprusi): When using syncer virtual workspace this condition would not be necessary anymore, since directly tested on the virtual workspace side.
+	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterFinalizerAnnotationPrefix+c.syncTargetKey] != ""
+
+	upstreamSyncerLister, err := c.getUpstreamLister(upstreamObjLogicalCluster, gvr)
+	if err != nil {
+		return err
+	}
+
+	logger = logger.WithValues(DownstreamName, transformedName)
+	ctx = klog.NewContext(ctx, logger)
+
+	logger.V(4).Info("Upstream object is intended to be removed", "intendedToBeRemovedFromLocation", intendedToBeRemovedFromLocation, "stillOwnedByExternalActorForLocation", stillOwnedByExternalActorForLocation)
+	if intendedToBeRemovedFromLocation && !stillOwnedByExternalActorForLocation {
+		var err error
+		if downstreamNamespace != "" {
+			err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Delete(ctx, transformedName, metav1.DeleteOptions{})
+		} else {
+			err = c.downstreamClient.Resource(gvr).Delete(ctx, transformedName, metav1.DeleteOptions{})
+		}
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// That's not an error.
+				// Just think about removing the finalizer from the KCP location-specific resource:
+				upstreamClient, err := c.getUpstreamClient(upstreamObjLogicalCluster)
+				if err != nil {
+					return err
+				}
+				return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, upstreamSyncerLister, upstreamClient, upstreamObj.GetNamespace(), c.syncTargetKey, upstreamObj.GetName())
+			}
+			logger.Error(err, "Error deleting upstream resource from downstream")
+			return err
+		}
+		if downstreamNamespace != "" {
+			c.downstreamNSCleaner.PlanCleaning(downstreamNamespace)
+		}
+		logger.V(2).Info("Deleted upstream resource from downstream")
+		return nil
+	}
+
+	// Run any transformations on the object before we apply it to the downstream cluster.
+	if mutator, ok := c.mutators[gvr]; ok {
+		if err := mutator.Mutate(downstreamObj); err != nil {
+			return err
+		}
+	}
+
+	downstreamObj.SetName(transformedName)
+	downstreamObj.SetUID("")
+	downstreamObj.SetResourceVersion("")
+	downstreamObj.SetNamespace(downstreamNamespace)
+	downstreamObj.SetManagedFields(nil)
+
+	// Strip cluster name annotation
+	downstreamAnnotations := downstreamObj.GetAnnotations()
+	delete(downstreamAnnotations, logicalcluster.AnnotationKey)
+	// TODO(jmprusi): To be removed when switching to the syncer Virtual Workspace transformations.
+	delete(downstreamAnnotations, workloadv1alpha1.InternalClusterStatusAnnotationPrefix+c.syncTargetKey)
+	// If the resource is cluster-scoped, we need to add the namespaceLocator annotation to get be able to
+	// find out the upstream resource from the downstream resource.
+	if downstreamNamespace == "" {
+		namespaceLocator := shared.NewNamespaceLocator(upstreamObjLogicalCluster, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, "")
+		namespaceLocatorJSONBytes, err := json.Marshal(namespaceLocator)
+		if err != nil {
+			return err
+		}
+		downstreamAnnotations[shared.NamespaceLocatorAnnotation] = string(namespaceLocatorJSONBytes)
+	}
+
+	// If we're left with 0 annotations, nil out the map so it's not included in the patch
+	if len(downstreamAnnotations) == 0 {
+		downstreamAnnotations = nil
+	}
+	downstreamObj.SetAnnotations(downstreamAnnotations)
+
+	// Deletion fields are immutable and set by the downstream API server
+	downstreamObj.SetDeletionTimestamp(nil)
+	downstreamObj.SetDeletionGracePeriodSeconds(nil)
+	// Strip owner references, to avoid orphaning by broken references,
+	// and make sure cascading deletion is only performed once upstream.
+	downstreamObj.SetOwnerReferences(nil)
+	// Strip finalizers to avoid the deletion of the downstream resource from being blocked.
+	downstreamObj.SetFinalizers(nil)
+
+	// replace upstream state label with downstream cluster label. We don't want to leak upstream state machine
+	// state to downstream, and also we don't need downstream updates every time the upstream state machine changes.
+	labels := downstreamObj.GetLabels()
+	delete(labels, workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetKey)
+	labels[workloadv1alpha1.InternalDownstreamClusterLabel] = c.syncTargetKey
+	downstreamObj.SetLabels(labels)
+
+	if c.advancedSchedulingEnabled {
+		specDiffPatch := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterSpecDiffAnnotationPrefix+c.syncTargetKey]
+		if specDiffPatch != "" {
+			upstreamSpec, specExists, err := unstructured.NestedFieldCopy(upstreamObj.UnstructuredContent(), "spec")
+			if err != nil {
+				return err
+			}
+			if specExists {
+				// TODO(jmprusi): Surface those errors to the user.
+				patch, err := jsonpatch.DecodePatch([]byte(specDiffPatch))
+				if err != nil {
+					logger.Error(err, "Failed to decode spec diff patch")
+					return err
+				}
+				upstreamSpecJSON, err := json.Marshal(upstreamSpec)
+				if err != nil {
+					return err
+				}
+				patchedUpstreamSpecJSON, err := patch.Apply(upstreamSpecJSON)
+				if err != nil {
+					return err
+				}
+				var newSpec map[string]interface{}
+				if err := json.Unmarshal(patchedUpstreamSpecJSON, &newSpec); err != nil {
+					return err
+				}
+				if err := unstructured.SetNestedMap(downstreamObj.UnstructuredContent(), newSpec, "spec"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Marshalling the unstructured object is good enough as SSA patch
+	data, err := json.Marshal(downstreamObj)
+	if err != nil {
+		return err
+	}
+
+	// Check if the resource is cluster-wide or namespaced and patch it appropriately.
+	if downstreamNamespace != "" {
+		_, err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Patch(ctx, downstreamObj.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: syncerApplyManager, Force: pointer.Bool(true)})
+	} else {
+		_, err = c.downstreamClient.Resource(gvr).Patch(ctx, downstreamObj.GetName(), types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: syncerApplyManager, Force: pointer.Bool(true)})
+	}
+
+	if err != nil {
+		logger.Error(err, "Error upserting upstream resource to downstream")
+		return err
+	}
+	logger.Info("Upserted upstream resource to downstream")
+
+	return nil
+}
+
+// getTransformedName returns the desired object name.
+func getTransformedName(syncedObject *unstructured.Unstructured) string {
+	configMapGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
+	secretGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
+
+	if syncedObject.GroupVersionKind() == configMapGVK && syncedObject.GetName() == "kube-root-ca.crt" {
+		return "kcp-root-ca.crt"
+	}
+	// Only rename the default-token-* secrets that are owned by the default SA.
+	if syncedObject.GroupVersionKind() == secretGVK && strings.HasPrefix(syncedObject.GetName(), "default-token-") {
+		if saName, ok := syncedObject.GetAnnotations()[corev1.ServiceAccountNameKey]; ok && saName == "default" {
+			return "kcp-" + syncedObject.GetName()
+		}
+	}
+	return syncedObject.GetName()
+}

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1,0 +1,1612 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec/dns"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec/mutators"
+	kcpcorev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = kcpcorev1alpha1.AddToScheme(scheme)
+}
+
+type mockedCleaner struct {
+	lock    sync.Mutex
+	toClean sets.Set[string]
+}
+
+func (c *mockedCleaner) PlanCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.toClean.Insert(key)
+}
+
+// CancelCleaning removes the key from the list of keys to be cleaned up.
+// If it wasn't planned for deletion, it does nothing.
+func (c *mockedCleaner) CancelCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.toClean.Delete(key)
+}
+
+func TestDeepEqualApartFromStatus(t *testing.T) {
+	type args struct {
+		a, b *unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "both objects are equals",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "both objects are equals as are being deleted",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":              "test_kind",
+						"apiVersion":        "test_version",
+						"deletionTimestamp": "2010-11-10T23:00:00Z",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":              "test_kind",
+						"apiVersion":        "test_version",
+						"deletionTimestamp": "2010-11-10T23:00:00Z",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "both objects are equals even they have different statuses",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":              "test_kind",
+						"apiVersion":        "test_version",
+						"deletionTimestamp": "2010-11-10T23:00:00Z",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+						"status": map[string]interface{}{},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":              "test_kind",
+						"apiVersion":        "test_version",
+						"deletionTimestamp": "2010-11-10T23:00:00Z",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+						"status": map[string]interface{}{
+							"phase": "Failed",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "both objects are equals even they have a different value in InternalClusterStatusAnnotationPrefix",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								workloadv1alpha1.InternalClusterStatusAnnotationPrefix: "2",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								workloadv1alpha1.InternalClusterStatusAnnotationPrefix: "1",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not equal as b is missing labels",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal as b has different labels values",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "another_test_value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal as b resource is missing annotations",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								"annotation": "this is an annotation",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal as b resource has different annotations",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								"annotation": "this is an annotation",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								"annotation":  "this is an annotation",
+								"annotation2": "this is another annotation",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal as b resource has finalizers",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"finalizers": []interface{}{
+								"finalizer.1",
+								"finalizer.2",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal even objects are equal as A is being deleted",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":              "test_name",
+							"namespace":         "test_namespace",
+							"deletionTimestamp": "2010-11-10T23:00:00Z",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								"test_annotation": "test_value",
+							},
+							"finalizers": []interface{}{
+								"finalizer.1",
+								"finalizer.2",
+							},
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+							"labels": map[string]interface{}{
+								"test_label": "test_value",
+							},
+							"annotations": map[string]interface{}{
+								"test_annotation": "test_value",
+							},
+							"finalizers": []interface{}{
+								"finalizer.1",
+								"finalizer.2",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "not equal as b has additional fields than a",
+			args: args{
+				a: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+					},
+				},
+				b: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "test_kind",
+						"apiVersion": "test_version",
+						"metadata": map[string]interface{}{
+							"name":      "test_name",
+							"namespace": "test_namespace",
+						},
+						"other_key": "other_value",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	logger := klog.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deepEqualApartFromStatus(logger, tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("deepEqualApartFromStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		appsv1.SchemeGroupVersion.WithResource("deployments"): {
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "deployment",
+				Kind:     "Deployment",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "configmaps",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "configmap",
+				Kind:     "ConfigMap",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "secrets",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "secret",
+				Kind:     "Secret",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
+func TestSpecSyncerProcess(t *testing.T) {
+	tests := map[string]struct {
+		fromNamespace *corev1.Namespace
+		gvr           schema.GroupVersionResource
+		fromResources []runtime.Object
+		toResources   []runtime.Object
+
+		resourceToProcessName               string
+		resourceToProcessLogicalClusterName string
+
+		upstreamURL               string
+		upstreamLogicalCluster    logicalcluster.Name
+		syncTargetName            string
+		syncTargetClusterName     logicalcluster.Name
+		syncTargetUID             types.UID
+		advancedSchedulingEnabled bool
+
+		expectError             bool
+		expectActionsOnFrom     []kcptesting.Action
+		expectActionsOnTo       []clienttesting.Action
+		expectNSCleaningPlanned []string
+	}{
+		"SpecSyncer sync deployment to downstream, upstream gets patched with the finalizer and the object is not created downstream (will be in the next reconciliation)": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, nil),
+			},
+			toResources: []runtime.Object{
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{
+				updateDeploymentAction("test",
+					toUnstructured(t, changeDeployment(
+						deployment("theDeployment", "test", "root:org:ws", map[string]string{
+							"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+						}, map[string]string{
+							"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+						}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+					))),
+			},
+			expectActionsOnTo: []clienttesting.Action{
+				createNamespaceSingleClusterAction(
+					"",
+					changeUnstructured(
+						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
+							map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+							},
+							map[string]string{
+								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+							})),
+						removeNilOrEmptyFields,
+					),
+				),
+			},
+		},
+		"SpecSyncer sync to downstream, syncer finalizer already there": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			toResources: []runtime.Object{
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				createNamespaceSingleClusterAction(
+					"",
+					changeUnstructured(
+						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
+							map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+							},
+							map[string]string{
+								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+							})),
+						removeNilOrEmptyFields,
+					),
+				),
+				patchDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+					types.ApplyPatchType,
+					toJson(t,
+						changeUnstructured(
+							toUnstructured(t, deployment("theDeployment", "kcp-33jbiactwhg0", "", map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+							}, map[string]string{
+								"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+							}, nil)),
+							setNestedField(map[string]interface{}{}, "status"),
+							setPodSpec("spec", "template", "spec"),
+						),
+					),
+				),
+			},
+		},
+		"SpecSyncer upstream resource has been removed, expect deletion downstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				deployment("theDeployment", "kcp-33jbiactwhg0", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				deleteDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+				),
+			},
+			expectNSCleaningPlanned: []string{"kcp-33jbiactwhg0"},
+		},
+		"SpecSyncer deletion: object exist downstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+				},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				deployment("theDeployment", "kcp-33jbiactwhg0", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{
+						"internal.workload.kcp.io/workspace-url":                                   "https://kcp.io/clusters/clusterName",
+						"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": time.Now().Format(time.RFC3339),
+					},
+					[]string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				deleteDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+				),
+			},
+			expectNSCleaningPlanned: []string{"kcp-33jbiactwhg0"},
+		},
+		"SpecSyncer deletion: object does not exists downstream, upstream finalizer should be removed": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+				},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{
+						"another.valid.annotation/this":                                            "value",
+						"internal.workload.kcp.io/workspace-url":                                   "https://kcp.io/clusters/clusterName",
+						"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": time.Now().Format(time.RFC3339),
+					},
+					[]string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+			expectActionsOnFrom: []kcptesting.Action{
+				updateDeploymentAction("test",
+					changeUnstructured(
+						toUnstructured(t, changeDeployment(
+							deployment("theDeployment", "test", "root:org:ws", nil, map[string]string{
+								"another.valid.annotation/this":          "value",
+								"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+							}, nil),
+						),
+						),
+						// TODO(jmprusi): Those next changes do "nothing", it's just for the test to pass
+						//                as the test expects some null fields to be there...
+						setNestedField(map[string]interface{}{}, "metadata", "labels"),
+						setNestedField([]interface{}{}, "metadata", "finalizers"),
+						setNestedField(nil, "spec", "selector"),
+					)),
+			},
+			expectActionsOnTo: []clienttesting.Action{
+				deleteDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+				),
+			},
+		},
+		"SpecSyncer deletion: upstream object has external finalizer, the object shouldn't be deleted": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+				},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				deployment("theDeployment", "kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, nil),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{
+						"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": time.Now().Format(time.RFC3339),
+						"internal.workload.kcp.io/workspace-url":                                   "https://kcp.io/clusters/clusterName",
+						"finalizers.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g":        "another-controller-finalizer",
+					},
+					[]string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				patchDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+					types.ApplyPatchType,
+					toJson(t,
+						changeUnstructured(
+							toUnstructured(t, deployment("theDeployment", "kcp-33jbiactwhg0", "", map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+							}, map[string]string{
+								"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": time.Now().Format(time.RFC3339),
+								"internal.workload.kcp.io/workspace-url":                                   "https://kcp.io/clusters/clusterName",
+								"finalizers.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g":        "another-controller-finalizer",
+							}, nil)),
+							// TODO(jmprusi): Those next changes do "nothing", it's just for the test to pass
+							//                as the test expects some null fields to be there...
+							setNestedField(nil, "spec", "selector"),
+							setNestedField(map[string]interface{}{}, "spec", "strategy"),
+							setNestedField(map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"creationTimestamp": nil,
+								},
+								"spec": map[string]interface{}{
+									"containers": nil,
+								},
+							}, "spec", "template"),
+							setNestedField(map[string]interface{}{}, "status"),
+							setPodSpec("spec", "template", "spec"),
+						),
+					),
+				),
+			},
+		},
+		"SpecSyncer with AdvancedScheduling, sync deployment to downstream and apply SpecDiff": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					},
+					map[string]string{
+						"experimental.spec-diff.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]",
+						"internal.workload.kcp.io/workspace-url":                                        "https://kcp.io/clusters/clusterName",
+					},
+					[]string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			toResources: []runtime.Object{
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+			advancedSchedulingEnabled:           true,
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				createNamespaceSingleClusterAction(
+					"",
+					changeUnstructured(
+						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
+							map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
+							},
+							map[string]string{
+								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+							})),
+						removeNilOrEmptyFields,
+					),
+				),
+				patchDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-33jbiactwhg0",
+					types.ApplyPatchType,
+					toJson(t,
+						changeUnstructured(
+							toUnstructured(t, deployment("theDeployment", "kcp-33jbiactwhg0", "", map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+							}, map[string]string{
+								"experimental.spec-diff.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]",
+								"internal.workload.kcp.io/workspace-url":                                        "https://kcp.io/clusters/clusterName",
+							}, nil)),
+							setNestedField(map[string]interface{}{
+								"replicas": int64(3),
+							}, "spec"),
+							// TODO(jmprusi): Those next changes do "nothing", it's just for the test to pass
+							//                as the test expects some null fields to be there...
+							setNestedField(nil, "spec", "selector"),
+							setNestedField(map[string]interface{}{}, "spec", "strategy"),
+							setNestedField(map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"creationTimestamp": nil,
+								},
+								"spec": map[string]interface{}{
+									"containers": nil,
+								},
+							}, "spec", "template"),
+							setNestedField(map[string]interface{}{}, "status"),
+						),
+					),
+				),
+			},
+		},
+		"SpecSyncer namespace conflict: try to sync to an already existing namespace with a different namespace-locator, expect error": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"ANOTHERNAMESPACE"}`,
+				}),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+			expectError:                         true,
+			expectActionsOnFrom:                 []kcptesting.Action{},
+			expectActionsOnTo:                   []clienttesting.Action{},
+		},
+		"SpecSyncer namespace conflict: try to sync to an already existing namespace without a namespace-locator, expect error": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, map[string]string{},
+				),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+			expectError:                         true,
+			expectActionsOnFrom:                 []kcptesting.Action{},
+			expectActionsOnTo:                   []clienttesting.Action{},
+		},
+		"old v0.6.0 namespace locator exists downstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			fromResources: []runtime.Object{
+				secretWithFinalizers("foo", "test", "root:org:ws",
+					map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+						"something": "else",
+					},
+					map[string]string{
+						"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+					},
+					[]string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"},
+					map[string][]byte{
+						"a": []byte("b"),
+					}),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-01c0zzvlqsi7n", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7"},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				secret("foo", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					nil,
+					map[string][]byte{
+						"a": []byte("b"),
+					}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "foo",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				patchSecretSingleClusterAction(
+					"foo",
+					"kcp-01c0zzvlqsi7n",
+					types.ApplyPatchType,
+					[]byte(`{"apiVersion":"v1","data":{"a":"Yg=="},"kind":"Secret","metadata":{"annotations":{"internal.workload.kcp.io/workspace-url":"https://kcp.io/clusters/clusterName"},"creationTimestamp":null,"labels":{"internal.workload.kcp.io/cluster":"6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g","something":"else"},"name":"foo","namespace":"kcp-01c0zzvlqsi7n"},"type":"kubernetes.io/service-account-token"}`),
+				),
+			},
+		},
+		"tenant label is added to existing downstream namespaces": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "root:org:ws", map[string]string{
+				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+			}, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-01c0zzvlqsi7n", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+			},
+			resourceToProcessLogicalClusterName: "root:org:ws",
+			resourceToProcessName:               "theDeployment",
+			syncTargetName:                      "us-west1",
+
+			expectActionsOnFrom: []kcptesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				updateNamespaceAction("kcp-01c0zzvlqsi7n",
+					toUnstructured(t, namespace("kcp-01c0zzvlqsi7n", "", map[string]string{
+						"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+						"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7"},
+						map[string]string{
+							"kcp.io/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+						}))),
+				patchDeploymentSingleClusterAction(
+					"theDeployment",
+					"kcp-01c0zzvlqsi7n",
+					types.ApplyPatchType,
+					toJson(t,
+						changeUnstructured(
+							toUnstructured(t, deployment("theDeployment", "kcp-01c0zzvlqsi7n", "", map[string]string{
+								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+							}, map[string]string{
+								"internal.workload.kcp.io/workspace-url": "https://kcp.io/clusters/clusterName",
+							}, nil)),
+							setNestedField(map[string]interface{}{}, "status"),
+							setPodSpec("spec", "template", "spec"),
+						),
+					),
+				),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := klog.FromContext(ctx)
+
+			kcpLogicalCluster := tc.upstreamLogicalCluster
+			syncTargetUID := tc.syncTargetUID
+			if tc.syncTargetUID == "" {
+				syncTargetUID = types.UID("syncTargetUID")
+			}
+
+			if tc.syncTargetClusterName.Empty() {
+				tc.syncTargetClusterName = "root:org:ws"
+			}
+
+			var allFromResources []runtime.Object
+			allFromResources = append(allFromResources, tc.fromNamespace)
+			if tc.fromResources != nil {
+				allFromResources = append(allFromResources, tc.fromResources...)
+			}
+
+			fromClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, allFromResources...)
+
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetClusterName, tc.syncTargetName)
+
+			toClient := dynamicfake.NewSimpleDynamicClient(scheme, tc.toResources...)
+			toKubeClient := kubefake.NewSimpleClientset(tc.toResources...)
+
+			ddsifForUpstreamSyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(fromClusterClient, nil, nil, &mockedGVRSource{}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(toClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			setupServersideApplyPatchReactor(toClient)
+			resourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClusterClient)
+
+			// toInformerFactory to watch some DNS-related resources in the dns namespace
+			toInformerFactory := informers.NewSharedInformerFactoryWithOptions(toKubeClient, time.Hour,
+				informers.WithNamespace("kcp-01c0zzvlqsi7n"))
+
+			require.NoError(t, err)
+
+			mockedCleaner := &mockedCleaner{
+				toClean: sets.New[string](),
+			}
+
+			secretMutator := mutators.NewSecretMutator()
+			podspecableMutator := mutators.NewPodspecableMutator(
+				func(clusterName logicalcluster.Name) (*ddsif.DiscoveringDynamicSharedInformerFactory, error) {
+					return ddsifForUpstreamSyncer, nil
+				}, toInformerFactory.Core().V1().Services().Lister(), tc.syncTargetClusterName, tc.syncTargetName, syncTargetUID, "kcp-01c0zzvlqsi7n", false)
+
+			dnsProcessor := dns.NewDNSProcessor(toKubeClient, toInformerFactory, tc.syncTargetName, syncTargetUID, "kcp-01c0zzvlqsi7n", "dnsimage")
+			controller, err := NewSpecSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, tc.advancedSchedulingEnabled,
+				fromClusterClient, toClient, toKubeClient, ddsifForUpstreamSyncer, ddsifForDownstream, mockedCleaner, syncTargetUID,
+				"kcp-01c0zzvlqsi7n", dnsProcessor, "dnsimage", secretMutator, podspecableMutator)
+			require.NoError(t, err)
+
+			toInformerFactory.Start(ctx.Done())
+			toInformerFactory.WaitForCacheSync(ctx.Done())
+
+			ddsifForUpstreamSyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamSyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
+
+			<-resourceWatcherStarted
+
+			// The only GVRs we care about are the 4 listed below
+			t.Logf("waiting for upstream and downstream dynamic informer factories to be synced")
+			gvrs := sets.New[string](
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}.String(),
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}.String(),
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}.String(),
+				schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}.String(),
+			)
+			require.Eventually(t, func() bool {
+				syncedUpstream, _ := ddsifForUpstreamSyncer.Informers()
+				foundUpstream := sets.New[string]()
+				for gvr := range syncedUpstream {
+					foundUpstream.Insert(gvr.String())
+				}
+
+				syncedDownstream, _ := ddsifForDownstream.Informers()
+				foundDownstream := sets.New[string]()
+				for gvr := range syncedDownstream {
+					foundDownstream.Insert(gvr.String())
+				}
+				return foundUpstream.IsSuperset(gvrs) && foundDownstream.IsSuperset(gvrs)
+			}, wait.ForeverTestTimeout, 100*time.Millisecond)
+			t.Logf("upstream and downstream dynamic informer factories are synced")
+
+			// Now that we know the informer factories have the GVRs we care about synced, we need to clear the
+			// actions so our expectations will be accurate.
+			fromClusterClient.ClearActions()
+			toClient.ClearActions()
+
+			key := kcpcache.ToClusterAwareKey(tc.resourceToProcessLogicalClusterName, tc.fromNamespace.Name, tc.resourceToProcessName)
+			_, err = controller.process(context.Background(),
+				tc.gvr,
+				key,
+			)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Path{})))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClient.Actions()))
+			mockedCleaner.lock.Lock()
+			defer mockedCleaner.lock.Unlock()
+			if tc.expectNSCleaningPlanned != nil {
+				assert.Equal(t, tc.expectNSCleaningPlanned, sets.List[string](mockedCleaner.toClean))
+			} else {
+				assert.Equal(t, []string{}, sets.List[string](mockedCleaner.toClean))
+			}
+		})
+	}
+}
+
+func setupServersideApplyPatchReactor(toClient *dynamicfake.FakeDynamicClient) {
+	toClient.PrependReactor("patch", "*", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(clienttesting.PatchAction)
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		return true, nil, err
+	})
+}
+
+func setupWatchReactor(resource string, fromClient *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	watcherStarted := make(chan struct{})
+	fromClient.PrependWatchReactor(resource, func(action kcptesting.Action) (bool, watch.Interface, error) {
+		cluster := action.GetCluster()
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		var watcher watch.Interface
+		var err error
+		switch cluster {
+		case logicalcluster.Wildcard:
+			watcher, err = fromClient.Tracker().Watch(gvr, ns)
+		default:
+			watcher, err = fromClient.Tracker().Cluster(cluster).Watch(gvr, ns)
+		}
+		close(watcherStarted)
+		return true, watcher, err
+	})
+	return watcherStarted
+}
+
+func namespace(name, clusterName string, labels, annotations map[string]string) *corev1.Namespace {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+	}
+
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+func deployment(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string) *appsv1.Deployment {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+			Finalizers:  finalizers,
+		},
+	}
+}
+
+func endpoints(name, namespace string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{Addresses: []corev1.EndpointAddress{
+				{
+					IP: "8.8.8.8",
+				}}},
+		},
+	}
+}
+
+func service(name, namespace string) *corev1.Service {
+	svc := dns.MakeService(name, namespace)
+	svc.Spec.ClusterIP = "8.8.8.8"
+	return svc
+}
+
+func secret(name, namespace, clusterName string, labels, annotations map[string]string, data map[string][]byte) *corev1.Secret {
+	return secretWithFinalizers(name, namespace, clusterName, labels, annotations, nil, data)
+}
+
+func secretWithFinalizers(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, data map[string][]byte) *corev1.Secret {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[logicalcluster.AnnotationKey] = clusterName
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+			Finalizers:  finalizers,
+		},
+		Data:       data,
+		StringData: nil,
+		Type:       corev1.SecretTypeServiceAccountToken,
+	}
+}
+
+type deploymentChange func(*appsv1.Deployment)
+
+func changeDeployment(in *appsv1.Deployment, changes ...deploymentChange) *appsv1.Deployment {
+	for _, change := range changes {
+		change(in)
+	}
+	return in
+}
+
+func toJson(t require.TestingT, object runtime.Object) []byte {
+	result, err := json.Marshal(object)
+	require.NoError(t, err)
+	return result
+}
+
+func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstructured {
+	var result unstructured.Unstructured
+	err := scheme.Convert(obj, &result, nil)
+	require.NoError(t, err)
+
+	return &result
+}
+
+type unstructuredChange func(d *unstructured.Unstructured)
+
+func changeUnstructured(in *unstructured.Unstructured, changes ...unstructuredChange) *unstructured.Unstructured {
+	for _, change := range changes {
+		change(in)
+	}
+	return in
+}
+
+func removeNilOrEmptyFields(in *unstructured.Unstructured) {
+	if val, exists, _ := unstructured.NestedFieldNoCopy(in.UnstructuredContent(), "metadata", "creationTimestamp"); val == nil && exists {
+		unstructured.RemoveNestedField(in.UnstructuredContent(), "metadata", "creationTimestamp")
+	}
+	if val, exists, _ := unstructured.NestedMap(in.UnstructuredContent(), "spec"); len(val) == 0 && exists {
+		delete(in.Object, "spec")
+	}
+	if val, exists, _ := unstructured.NestedMap(in.UnstructuredContent(), "status"); len(val) == 0 && exists {
+		delete(in.Object, "status")
+	}
+}
+
+func setNestedField(value interface{}, fields ...string) unstructuredChange {
+	return func(d *unstructured.Unstructured) {
+		_ = unstructured.SetNestedField(d.UnstructuredContent(), value, fields...)
+	}
+}
+
+func setPodSpec(fields ...string) unstructuredChange {
+	var j interface{}
+	err := json.Unmarshal([]byte(`{
+	"dnsConfig": {
+       "nameservers": [ "8.8.8.8" ],
+       "options": [{ "name": "ndots", "value": "5"}],
+       "searches": ["test.svc.cluster.local", "svc.cluster.local", "cluster.local"]
+    },
+	"dnsPolicy": "None",
+	"automountServiceAccountToken":false,
+	"containers":null,
+	"volumes":[
+		{"name":"kcp-api-access","projected":{
+			"defaultMode":420,
+			"sources":[
+				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name": "kcp-default-token-abc"}},
+				{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kcp-root-ca.crt"}}
+			]
+		}}
+	]
+}`), &j)
+	if err != nil {
+		panic(err)
+	}
+	return setNestedField(j, fields...)
+}
+
+func deploymentAction(verb, namespace string, subresources ...string) kcptesting.ActionImpl {
+	return kcptesting.ActionImpl{
+		Namespace:   namespace,
+		ClusterPath: logicalcluster.NewPath("root:org:ws"),
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func updateDeploymentAction(namespace string, object runtime.Object, subresources ...string) kcptesting.UpdateActionImpl {
+	return kcptesting.UpdateActionImpl{
+		ActionImpl: deploymentAction("update", namespace, subresources...),
+		Object:     object,
+	}
+}
+
+func deploymentSingleClusterAction(verb, namespace string, subresources ...string) clienttesting.ActionImpl {
+	return clienttesting.ActionImpl{
+		Namespace:   namespace,
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func namespaceSingleClusterAction(verb string, subresources ...string) clienttesting.ActionImpl {
+	return clienttesting.ActionImpl{
+		Namespace:   "",
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func createNamespaceSingleClusterAction(name string, object runtime.Object) clienttesting.CreateActionImpl {
+	return clienttesting.CreateActionImpl{
+		ActionImpl: namespaceSingleClusterAction("create"),
+		Name:       name,
+		Object:     object,
+	}
+}
+
+func patchDeploymentSingleClusterAction(name, namespace string, patchType types.PatchType, patch []byte, subresources ...string) clienttesting.PatchActionImpl {
+	return clienttesting.PatchActionImpl{
+		ActionImpl: deploymentSingleClusterAction("patch", namespace, subresources...),
+		Name:       name,
+		PatchType:  patchType,
+		Patch:      patch,
+	}
+}
+
+func deleteDeploymentSingleClusterAction(name, namespace string, subresources ...string) clienttesting.DeleteActionImpl {
+	return clienttesting.DeleteActionImpl{
+		ActionImpl:    deploymentSingleClusterAction("delete", namespace, subresources...),
+		Name:          name,
+		DeleteOptions: metav1.DeleteOptions{},
+	}
+}
+
+func secretSingleClusterAction(verb, namespace string, subresources ...string) clienttesting.ActionImpl {
+	return clienttesting.ActionImpl{
+		Namespace:   namespace,
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func patchSecretSingleClusterAction(name, namespace string, patchType types.PatchType, patch []byte, subresources ...string) clienttesting.PatchActionImpl {
+	return clienttesting.PatchActionImpl{
+		ActionImpl: secretSingleClusterAction("patch", namespace, subresources...),
+		Name:       name,
+		PatchType:  patchType,
+		Patch:      patch,
+	}
+}
+
+func namespaceAction(verb, namespace string, subresources ...string) clienttesting.ActionImpl {
+	return clienttesting.ActionImpl{
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func updateNamespaceAction(namespace string, object runtime.Object, subresources ...string) clienttesting.UpdateActionImpl {
+	return clienttesting.UpdateActionImpl{
+		ActionImpl: namespaceAction("update", namespace, subresources...),
+		Object:     object,
+	}
+}

--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+const (
+	controllerName = "kcp-workload-syncer-status"
+)
+
+var namespaceGVR schema.GroupVersionResource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+
+type Controller struct {
+	queue workqueue.RateLimitingInterface
+
+	getUpstreamClient func(clusterName logicalcluster.Name) (dynamic.Interface, error)
+	downstreamClient  dynamic.Interface
+
+	getUpstreamLister   func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	getDownstreamLister func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+
+	syncTargetName            string
+	syncTargetWorkspace       logicalcluster.Name
+	syncTargetUID             types.UID
+	syncTargetKey             string
+	advancedSchedulingEnabled bool
+}
+
+func NewStatusSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name, syncTargetName, syncTargetKey string, advancedSchedulingEnabled bool,
+	getShardAccess synctarget.GetShardAccessFunc,
+	downstreamClient dynamic.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	syncTargetUID types.UID) (*Controller, error) {
+	c := &Controller{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+
+		getUpstreamClient: func(clusterName logicalcluster.Name) (dynamic.Interface, error) {
+			shardAccess, ok, err := getShardAccess(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+			return shardAccess.SyncerClient.Cluster(clusterName.Path()), nil
+		},
+		downstreamClient: downstreamClient,
+
+		getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory - should retry", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			return informer.Lister(), nil
+		},
+		getUpstreamLister: func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			shardAccess, ok, err := getShardAccess(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+
+			informers, notSynced := shardAccess.SyncerDDSIF.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the upstream syncer informer factory -  should retry", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the upstream syncer informer factory", gvr)
+			}
+			return informer.Lister().ByCluster(clusterName), nil
+		},
+
+		syncTargetName:            syncTargetName,
+		syncTargetWorkspace:       syncTargetClusterName,
+		syncTargetUID:             syncTargetUID,
+		syncTargetKey:             syncTargetKey,
+		advancedSchedulingEnabled: advancedSchedulingEnabled,
+	}
+
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	namespaceGVR := corev1.SchemeGroupVersion.WithResource("namespaces")
+
+	ddsifForDownstream.AddEventHandler(
+		ddsif.GVREventHandlerFuncs{
+			AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				unstrObj, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", unstrObj))
+					return
+				}
+				if unstrObj.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+					return
+				}
+
+				c.AddToQueue(gvr, obj, logger)
+			},
+			UpdateFunc: func(gvr schema.GroupVersionResource, oldObj, newObj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				oldUnstrob := oldObj.(*unstructured.Unstructured)
+				newUnstrob := newObj.(*unstructured.Unstructured)
+				if newUnstrob.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+					return
+				}
+				if !deepEqualFinalizersAndStatus(oldUnstrob, newUnstrob) {
+					c.AddToQueue(gvr, newUnstrob, logger)
+				}
+			},
+			DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if gvr == namespaceGVR {
+					return
+				}
+				if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+					obj = d.Obj
+				}
+				unstrObj, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					runtime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", unstrObj))
+					return
+				}
+				if unstrObj.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+					return
+				}
+
+				c.AddToQueue(gvr, obj, logger)
+			},
+		})
+
+	return c, nil
+}
+
+type queueKey struct {
+	gvr schema.GroupVersionResource
+	key string // meta namespace key
+}
+
+func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}, logger logr.Logger) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(2).Info("queueing GVR", "gvr", gvr.String())
+	c.queue.Add(
+		queueKey{
+			gvr: gvr,
+			key: key,
+		},
+	)
+}
+
+// Start starts N worker processes processing work items.
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting syncer workers")
+	defer logger.Info("Stopping syncer workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	qk := key.(queueKey)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), qk.key).WithValues("gvr", qk.gvr.String())
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, qk.gvr, qk.key); err != nil {
+		runtime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	workloadcliplugin "github.com/kcp-dev/kcp/pkg/cliplugins/workload/plugin"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+func deepEqualFinalizersAndStatus(oldUnstrob, newUnstrob *unstructured.Unstructured) bool {
+	newFinalizers := newUnstrob.GetFinalizers()
+	oldFinalizers := oldUnstrob.GetFinalizers()
+
+	newStatus := newUnstrob.UnstructuredContent()["status"]
+	oldStatus := oldUnstrob.UnstructuredContent()["status"]
+
+	return equality.Semantic.DeepEqual(oldFinalizers, newFinalizers) && equality.Semantic.DeepEqual(oldStatus, newStatus)
+}
+
+func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string) error {
+	logger := klog.FromContext(ctx)
+
+	// from downstream
+	downstreamNamespace, downstreamName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "Invalid key")
+		return nil
+	}
+	// TODO(sttts): do not reference the cli plugin here
+	if strings.HasPrefix(downstreamNamespace, workloadcliplugin.SyncerIDPrefix) {
+		// skip syncer namespace
+		return nil
+	}
+
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace, DownstreamName, downstreamName)
+
+	downstreamLister, err := c.getDownstreamLister(gvr)
+	if err != nil {
+		return err
+	}
+
+	var namespaceLocator *shared.NamespaceLocator
+	var locatorExists bool
+
+	if downstreamNamespace != "" {
+		downstreamNamespaceLister, err := c.getDownstreamLister(namespaceGVR)
+		if err != nil {
+			return err
+		}
+
+		nsObj, err := downstreamNamespaceLister.Get(downstreamNamespace)
+		if err != nil {
+			logger.Error(err, "Error retrieving downstream namespace from downstream lister")
+			return nil
+		}
+		nsMeta, ok := nsObj.(metav1.Object)
+		if !ok {
+			logger.Info(fmt.Sprintf("Error: downstream namespace expected to be metav1.Object, got %T", nsObj))
+			return nil
+		}
+
+		namespaceLocator, locatorExists, err = shared.LocatorFromAnnotations(nsMeta.GetAnnotations())
+		if err != nil {
+			logger.Error(err, "Error decoding annotation on downstream namespace")
+			return nil
+		}
+		if !locatorExists || namespaceLocator == nil {
+			// Only sync resources for the configured logical cluster to ensure
+			// that syncers for multiple logical clusters can coexist.
+			return nil
+		}
+	}
+
+	var resourceExists bool
+	obj, err := downstreamLister.ByNamespace(downstreamNamespace).Get(downstreamName)
+	if err == nil {
+		resourceExists = true
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if downstreamNamespace == "" {
+		if !resourceExists {
+			// TODO(davidfestal): The downstream object doesn't exist, but we cannot remove the finalizer
+			// on the upstream resource since we dont have the locator to locate the upstream resource.
+			// That should be fixed.
+			return nil
+		}
+
+		objMeta, ok := obj.(metav1.Object)
+		if !ok {
+			logger.Info(fmt.Sprintf("Error: downstream cluster-wide resource expected to be metav1.Object, got %T", obj))
+			return nil
+		}
+		namespaceLocator, locatorExists, err = shared.LocatorFromAnnotations(objMeta.GetAnnotations())
+		if err != nil {
+			logger.Error(err, "Error decoding annotation on downstream cluster-wide resource")
+			return nil
+		}
+		if !locatorExists || namespaceLocator == nil {
+			// Only sync resources for the configured logical cluster to ensure
+			// that syncers for multiple logical clusters can coexist.
+			return nil
+		}
+	}
+	if namespaceLocator.SyncTarget.UID != c.syncTargetUID || namespaceLocator.SyncTarget.ClusterName != c.syncTargetWorkspace.String() {
+		// not our resource.
+		return nil
+	}
+
+	upstreamNamespace := namespaceLocator.Namespace
+	upstreamClusterName := namespaceLocator.ClusterName
+	upstreamName := shared.GetUpstreamResourceName(gvr, downstreamName)
+
+	logger = logger.WithValues(logging.WorkspaceKey, upstreamClusterName, logging.NamespaceKey, upstreamNamespace, logging.NameKey, upstreamName)
+	ctx = klog.NewContext(ctx, logger)
+
+	upstreamLister, err := c.getUpstreamLister(upstreamClusterName, gvr)
+	if err != nil {
+		return err
+	}
+
+	upstreamClient, err := c.getUpstreamClient(upstreamClusterName)
+	if err != nil {
+		return err
+	}
+
+	if !resourceExists {
+		logger.Info("Downstream object does not exist. Removing finalizer on upstream object")
+		return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, upstreamLister, upstreamClient, upstreamNamespace, c.syncTargetKey, shared.GetUpstreamResourceName(gvr, downstreamName))
+	}
+
+	// update upstream status
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("object to synchronize is expected to be Unstructured, but is %T", obj)
+	}
+	if u.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetKey] == string(workloadv1alpha1.ResourceStateUpsync) {
+		logger.V(4).Info("do not update the status in upstream, since the downstream resource is in Upsync mode")
+		return nil
+	}
+
+	return c.updateStatusInUpstream(ctx, gvr, upstreamClient, upstreamLister, upstreamNamespace, upstreamName, u)
+}
+
+func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamClient dynamic.Interface, upstreamLister cache.GenericLister, upstreamNamespace, upstreamName string, downstreamObj *unstructured.Unstructured) error {
+	logger := klog.FromContext(ctx)
+
+	downstreamStatus, statusExists, err := unstructured.NestedFieldCopy(downstreamObj.UnstructuredContent(), "status")
+	if err != nil {
+		return err
+	} else if !statusExists {
+		logger.V(5).Info("Downstream resource doesn't contain a status. Skipping updating the status of upstream resource")
+		return nil
+	}
+
+	existingObj, err := upstreamLister.ByNamespace(upstreamNamespace).Get(upstreamName)
+	if err != nil {
+		logger.Error(err, "Error getting upstream resource")
+		return err
+	}
+
+	existing, ok := existingObj.(*unstructured.Unstructured)
+	if !ok {
+		logger.Info(fmt.Sprintf("Error: Upstream resource expected to be *unstructured.Unstructured, got %T", existing))
+		return nil
+	}
+
+	newUpstream := existing.DeepCopy()
+
+	if c.advancedSchedulingEnabled {
+		statusAnnotationValue, err := json.Marshal(downstreamStatus)
+		if err != nil {
+			return err
+		}
+		newUpstreamAnnotations := newUpstream.GetAnnotations()
+		if newUpstreamAnnotations == nil {
+			newUpstreamAnnotations = make(map[string]string)
+		}
+		newUpstreamAnnotations[workloadv1alpha1.InternalClusterStatusAnnotationPrefix+c.syncTargetKey] = string(statusAnnotationValue)
+		newUpstream.SetAnnotations(newUpstreamAnnotations)
+
+		if reflect.DeepEqual(existing, newUpstream) {
+			logger.V(2).Info("No need to update the status annotation of upstream resource")
+			return nil
+		}
+
+		if upstreamNamespace != "" {
+			// In this case we will update the whole resource, not the status, as the status is in the annotation.
+			// this is specific to the advancedScheduling flag.
+			_, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Update(ctx, newUpstream, metav1.UpdateOptions{})
+		} else {
+			_, err = upstreamClient.Resource(gvr).Update(ctx, newUpstream, metav1.UpdateOptions{})
+		}
+
+		if err != nil {
+			logger.Error(err, "Failed updating the status annotation of upstream resource")
+			return err
+		}
+		logger.Info("Updated the status annotation of upstream resource")
+		return nil
+	}
+
+	if err := unstructured.SetNestedField(newUpstream.UnstructuredContent(), downstreamStatus, "status"); err != nil {
+		logger.Error(err, "Failed setting status of upstream resource")
+		return err
+	}
+
+	// TODO (davidfestal): Here in the future we might want to also set some fields of the Spec, per resource type, for example:
+	// clusterIP for service, or other field values set by SyncTarget cluster admission.
+	// But for now let's only update the status.
+	if upstreamNamespace != "" {
+		_, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).UpdateStatus(ctx, newUpstream, metav1.UpdateOptions{})
+	} else {
+		_, err = upstreamClient.Resource(gvr).UpdateStatus(ctx, newUpstream, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		logger.Error(err, "Failed updating status of upstream resource")
+		return err
+	}
+
+	logger.Info("Updated status of upstream resource")
+	return nil
+}

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -1,0 +1,821 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+}
+
+func TestDeepEqualFinalizersAndStatus(t *testing.T) {
+	for _, c := range []struct {
+		desc     string
+		old, new *unstructured.Unstructured
+		want     bool
+	}{{
+		desc: "both objects have same status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "both objects have status; different",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "no",
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "one object doesn't have status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		want: false,
+	}, {
+		desc: "both objects don't have status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		want: true,
+	}, {
+		desc: "both objects have the same finalizers",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "one object doesn't have finalizers",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{},
+			},
+		},
+		want: false,
+	}, {
+		desc: "both objects don't have finalizers",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{},
+			},
+		},
+		want: true,
+	}, {
+		desc: "objects have different finalizers",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.2",
+						"finalizer.3",
+					},
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "one object doesn't have finalizers",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{},
+			},
+		},
+		want: false,
+	}, {
+		desc: "objects have the same status and finalizers but different labels",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"cool": "yes",
+					},
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"cool": "no!",
+					},
+					"finalizers": []interface{}{
+						"finalizer.1",
+						"finalizer.2",
+					},
+				},
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		want: true,
+	},
+		{
+			desc: "objects have equal finalizers and statuses",
+			old: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"finalizer.1",
+							"finalizer.2",
+						},
+					},
+					"status": map[string]string{
+						"cool": "yes",
+					},
+				},
+			},
+			new: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"finalizers": []interface{}{
+							"finalizer.1",
+							"finalizer.2",
+						},
+					},
+					"status": map[string]string{
+						"cool": "yes",
+					},
+				},
+			},
+			want: true,
+		}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := deepEqualFinalizersAndStatus(c.old, c.new)
+			if got != c.want {
+				t.Fatalf("got %t, want %t", got, c.want)
+			}
+		})
+	}
+}
+
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		appsv1.SchemeGroupVersion.WithResource("deployments"): {
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "deployment",
+				Kind:     "Deployment",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "configmaps",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "configmap",
+				Kind:     "ConfigMap",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "secrets",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "secret",
+				Kind:     "Secret",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
+func TestStatusSyncerProcess(t *testing.T) {
+	tests := map[string]struct {
+		fromNamespace *corev1.Namespace
+		gvr           schema.GroupVersionResource
+		fromResource  runtime.Object
+		toResources   []runtime.Object
+
+		resourceToProcessName string
+
+		upstreamURL               string
+		upstreamLogicalCluster    logicalcluster.Name
+		syncTargetName            string
+		syncTargetClusterName     logicalcluster.Name
+		syncTargetUID             types.UID
+		advancedSchedulingEnabled bool
+
+		expectError         bool
+		expectActionsOnFrom []clienttesting.Action
+		expectActionsOnTo   []kcptesting.Action
+	}{
+		"StatusSyncer upsert to existing resource": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: changeDeployment(
+				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, nil),
+				addDeploymentStatus(appsv1.DeploymentStatus{
+					Replicas: 15,
+				})),
+			toResources: []runtime.Object{
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, nil, nil),
+			},
+			resourceToProcessName: "theDeployment",
+			syncTargetName:        "us-west1",
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo: []kcptesting.Action{
+				updateDeploymentAction("test",
+					toUnstructured(t, changeDeployment(
+						deployment("theDeployment", "test", "root:org:ws", map[string]string{
+							"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+						}, nil, nil),
+						addDeploymentStatus(appsv1.DeploymentStatus{
+							Replicas: 15,
+						}))),
+					"status"),
+			},
+		},
+		"StatusSyncer upsert to existing resource but owned by another synctarget, expect no update": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"ANOTHERSYNCTARGETUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: changeDeployment(
+				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, nil),
+				addDeploymentStatus(appsv1.DeploymentStatus{
+					Replicas: 15,
+				})),
+			toResources: []runtime.Object{
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, nil, nil),
+			},
+			resourceToProcessName: "theDeployment",
+			syncTargetName:        "us-west1",
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo:   []kcptesting.Action{},
+		},
+		"StatusSyncer upstream deletion": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: changeDeployment(
+				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", nil, nil, nil),
+				addDeploymentStatus(appsv1.DeploymentStatus{
+					Replicas: 15,
+				})),
+			toResources: []runtime.Object{
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, nil, nil),
+			},
+			resourceToProcessName: "theDeployment",
+			syncTargetName:        "us-west1",
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo:   []kcptesting.Action{},
+		},
+		"StatusSyncer with AdvancedScheduling, update status upstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: changeDeployment(
+				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, nil),
+				addDeploymentStatus(appsv1.DeploymentStatus{
+					Replicas: 15,
+				})),
+			toResources: []runtime.Object{
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, nil, nil),
+			},
+			resourceToProcessName:     "theDeployment",
+			syncTargetName:            "us-west1",
+			advancedSchedulingEnabled: true,
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo: []kcptesting.Action{
+				updateDeploymentAction("test",
+					toUnstructured(t, changeDeployment(
+						deployment("theDeployment", "test", "root:org:ws", map[string]string{
+							"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+						}, map[string]string{
+							"experimental.status.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "{\"replicas\":15}",
+						}, nil)))),
+			},
+		},
+		"StatusSyncer with AdvancedScheduling, deletion: object exists upstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: changeDeployment(
+				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, nil),
+				addDeploymentStatus(appsv1.DeploymentStatus{
+					Replicas: 15,
+				})),
+			toResources: []runtime.Object{
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g":   time.Now().Format(time.RFC3339),
+					"experimental.status.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "{\"replicas\":15}",
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			resourceToProcessName:     "theDeployment",
+			syncTargetName:            "us-west1",
+			advancedSchedulingEnabled: true,
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo:   []kcptesting.Action{},
+		},
+		"StatusSyncer with AdvancedScheduling, deletion: object does not exists upstream": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+				map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+				map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+				}),
+			gvr:          schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResource: nil,
+			toResources: []runtime.Object{
+				namespace("test", "root:org:ws", map[string]string{"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync"}, nil),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+				}, map[string]string{
+					"deletion.internal.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g":   time.Now().Format(time.RFC3339),
+					"experimental.status.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": `{"replicas":15}`,
+				}, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+			},
+			resourceToProcessName:     "theDeployment",
+			syncTargetName:            "us-west1",
+			advancedSchedulingEnabled: true,
+
+			expectActionsOnFrom: []clienttesting.Action{},
+			expectActionsOnTo: []kcptesting.Action{
+				updateDeploymentAction("test",
+					changeUnstructured(
+						toUnstructured(t, changeDeployment(
+							deployment("theDeployment", "test", "root:org:ws", map[string]string{}, map[string]string{}, nil))),
+						// The following "changes" are required for the test to pass, as it expects some empty/nil fields to be there
+						setNestedField(map[string]interface{}{}, "metadata", "labels"),
+						setNestedField([]interface{}{}, "metadata", "finalizers"),
+						setNestedField(nil, "spec", "selector"),
+					),
+				),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := klog.FromContext(ctx)
+
+			kcpLogicalCluster := tc.upstreamLogicalCluster
+			if tc.syncTargetUID == "" {
+				tc.syncTargetUID = types.UID("syncTargetUID")
+			}
+			if tc.syncTargetClusterName.Empty() {
+				tc.syncTargetClusterName = "root:org:ws"
+			}
+
+			var allFromResources []runtime.Object
+			allFromResources = append(allFromResources, tc.fromNamespace)
+			if tc.fromResource != nil {
+				allFromResources = append(allFromResources, tc.fromResource)
+			}
+			fromClient := dynamicfake.NewSimpleDynamicClient(scheme, allFromResources...)
+			toClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, tc.toResources...)
+
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetClusterName, tc.syncTargetName)
+
+			ddsifForUpstreamSyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(toClusterClient, nil, nil, &mockedGVRSource{}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(fromClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			setupServersideApplyPatchReactor(toClusterClient)
+			fromClientResourceWatcherStarted := setupWatchReactor(t, tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupClusterWatchReactor(t, tc.gvr.Resource, toClusterClient)
+
+			getShardAccess := func(clusterName logicalcluster.Name) (synctarget.ShardAccess, bool, error) {
+				return synctarget.ShardAccess{
+					SyncerClient: toClusterClient,
+					SyncerDDSIF:  ddsifForUpstreamSyncer,
+				}, true, nil
+			}
+			controller, err := NewStatusSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, tc.advancedSchedulingEnabled, getShardAccess, fromClient, ddsifForDownstream, tc.syncTargetUID)
+			require.NoError(t, err)
+
+			ddsifForUpstreamSyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamSyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
+
+			<-fromClientResourceWatcherStarted
+			<-toClientResourceWatcherStarted
+
+			// The only GVRs we care about are the 4 listed below
+			t.Logf("waiting for upstream and downstream dynamic informer factories to be synced")
+			gvrs := sets.New[string](
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}.String(),
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}.String(),
+				schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}.String(),
+				schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}.String(),
+			)
+			require.Eventually(t, func() bool {
+				syncedUpstream, _ := ddsifForUpstreamSyncer.Informers()
+				foundUpstream := sets.New[string]()
+				for gvr := range syncedUpstream {
+					foundUpstream.Insert(gvr.String())
+				}
+
+				syncedDownstream, _ := ddsifForDownstream.Informers()
+				foundDownstream := sets.New[string]()
+				for gvr := range syncedDownstream {
+					foundDownstream.Insert(gvr.String())
+				}
+				return foundUpstream.IsSuperset(gvrs) && foundDownstream.IsSuperset(gvrs)
+			}, wait.ForeverTestTimeout, 100*time.Millisecond)
+			t.Logf("upstream and downstream dynamic informer factories are synced")
+
+			// Now that we know the informer factories have the GVRs we care about synced, we need to clear the
+			// actions so our expectations will be accurate.
+			fromClient.ClearActions()
+			toClusterClient.ClearActions()
+
+			key := tc.fromNamespace.Name + "/" + tc.resourceToProcessName
+			err = controller.process(context.Background(),
+				schema.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+				key,
+			)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClient.Actions()))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Path{})))
+		})
+	}
+}
+
+func setupServersideApplyPatchReactor(toClient *kcpfakedynamic.FakeDynamicClusterClientset) {
+	toClient.PrependReactor("patch", "*", func(action kcptesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kcptesting.PatchAction)
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		return true, nil, err
+	})
+}
+
+func setupWatchReactor(t *testing.T, resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+	t.Helper()
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		t.Logf("%s: watcher started", t.Name())
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	return watcherStarted
+}
+
+func setupClusterWatchReactor(t *testing.T, resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	t.Helper()
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action kcptesting.Action) (bool, watch.Interface, error) {
+		cluster := action.GetCluster()
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		var watcher watch.Interface
+		var err error
+		switch cluster {
+		case logicalcluster.Wildcard:
+			watcher, err = client.Tracker().Watch(gvr, ns)
+		default:
+			watcher, err = client.Tracker().Cluster(cluster).Watch(gvr, ns)
+		}
+		t.Logf("%s: cluster watcher started", t.Name())
+		close(watcherStarted)
+		return true, watcher, err
+	})
+	return watcherStarted
+}
+
+func namespace(name, clusterName string, labels, annotations map[string]string) *corev1.Namespace {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+	}
+
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+func deployment(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string) *appsv1.Deployment {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+			Finalizers:  finalizers,
+		},
+	}
+}
+
+type deploymentChange func(*appsv1.Deployment)
+
+func changeDeployment(in *appsv1.Deployment, changes ...deploymentChange) *appsv1.Deployment {
+	for _, change := range changes {
+		change(in)
+	}
+	return in
+}
+
+func addDeploymentStatus(status appsv1.DeploymentStatus) deploymentChange {
+	return func(d *appsv1.Deployment) {
+		d.Status = status
+	}
+}
+
+func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstructured {
+	var result unstructured.Unstructured
+	err := scheme.Convert(obj, &result, nil)
+	require.NoError(t, err)
+
+	return &result
+}
+
+type unstructuredChange func(d *unstructured.Unstructured)
+
+func changeUnstructured(in *unstructured.Unstructured, changes ...unstructuredChange) *unstructured.Unstructured {
+	for _, change := range changes {
+		change(in)
+	}
+	return in
+}
+
+func setNestedField(value interface{}, fields ...string) unstructuredChange {
+	return func(d *unstructured.Unstructured) {
+		_ = unstructured.SetNestedField(d.UnstructuredContent(), value, fields...)
+	}
+}
+
+func deploymentAction(verb, namespace string, subresources ...string) kcptesting.ActionImpl {
+	return kcptesting.ActionImpl{
+		Namespace:   namespace,
+		ClusterPath: logicalcluster.NewPath("root:org:ws"),
+		Verb:        verb,
+		Resource:    schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		Subresource: strings.Join(subresources, "/"),
+	}
+}
+
+func updateDeploymentAction(namespace string, object runtime.Object, subresources ...string) kcptesting.UpdateActionImpl {
+	return kcptesting.UpdateActionImpl{
+		ActionImpl: deploymentAction("update", namespace, subresources...),
+		Object:     object,
+	}
+}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -1,0 +1,568 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	kubernetesinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/module"
+
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/controllermanager"
+	"github.com/kcp-dev/kcp/pkg/syncer/endpoints"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/namespace"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec/dns"
+	"github.com/kcp-dev/kcp/pkg/syncer/spec/mutators"
+	"github.com/kcp-dev/kcp/pkg/syncer/status"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	"github.com/kcp-dev/kcp/pkg/syncer/upsync"
+	kcpcorev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned"
+	kcpclusterclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	kcpinformers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+const (
+	AdvancedSchedulingFeatureAnnotation = "featuregates.experimental.workload.kcp.io/advancedscheduling"
+
+	resyncPeriod = 10 * time.Hour
+
+	// TODO(marun) Coordinate this value with the interval configured for the heartbeat controller.
+	heartbeatInterval = 20 * time.Second
+)
+
+// SyncerConfig defines the syncer configuration that is guaranteed to
+// vary across syncer deployments. Capturing these details in a struct
+// simplifies defining these details in test fixture.
+type SyncerConfig struct {
+	UpstreamConfig                *rest.Config
+	DownstreamConfig              *rest.Config
+	ResourcesToSync               sets.Set[string]
+	SyncTargetPath                logicalcluster.Path
+	SyncTargetName                string
+	SyncTargetUID                 string
+	DownstreamNamespaceCleanDelay time.Duration
+	DNSImage                      string
+}
+
+func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration, syncerNamespace string) error {
+	return startSyncerWithModules(ctx, cfg, numSyncerThreads, importPollInterval, syncerNamespace, nil)
+}
+
+// startSyncerWithModules starts the syncer using the provided modules. External callers
+// should use StartSyncer unless customizing the modules.
+func startSyncerWithModules(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration, syncerNamespace string, modules *module.Modules) error {
+	if modules == nil {
+		modules = &module.Modules{}
+	}
+	modules.ApplyDefaults()
+
+	logger := klog.FromContext(ctx)
+	logger = logger.WithValues(SyncTargetWorkspace, cfg.SyncTargetPath, SyncTargetName, cfg.SyncTargetName)
+
+	logger.V(2).Info("starting syncer")
+
+	kcpVersion := version.Get().GitVersion
+
+	bootstrapConfig := rest.CopyConfig(cfg.UpstreamConfig)
+	rest.AddUserAgent(bootstrapConfig, "kcp#syncer/"+kcpVersion)
+	kcpBootstrapClusterClient, err := kcpclusterclientset.NewForConfig(bootstrapConfig)
+	if err != nil {
+		return err
+	}
+	kcpSyncTargetClient := kcpBootstrapClusterClient.Cluster(cfg.SyncTargetPath)
+
+	// kcpSyncTargetInformerFactory to watch a certain syncTarget
+	kcpSyncTargetInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(kcpSyncTargetClient, resyncPeriod, kcpinformers.WithTweakListOptions(
+		func(listOptions *metav1.ListOptions) {
+			listOptions.FieldSelector = fields.OneTermEqualSelector("metadata.name", cfg.SyncTargetName).String()
+		},
+	))
+
+	// TODO(david): we need to provide user-facing details if this polling goes on forever. Blocking here is a bad UX.
+	// TODO(david): Also, any regressions in our code will make any e2e test that starts a syncer (at least in-process)
+	// TODO(david): block until it hits the 10 minute overall test timeout.
+	logger.Info("attempting to retrieve the Syncer SyncTarget resource")
+	var syncTarget *workloadv1alpha1.SyncTarget
+	err = wait.PollImmediateInfinite(5*time.Second, func() (bool, error) {
+		var err error
+		syncTarget, err = kcpSyncTargetClient.WorkloadV1alpha1().SyncTargets().Get(ctx, cfg.SyncTargetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// If the SyncTargetUID flag is set, we compare the provided value with the kcp synctarget uid, if the values don't match
+		// the syncer will refuse to work.
+		if cfg.SyncTargetUID != "" && cfg.SyncTargetUID != string(syncTarget.UID) {
+			return false, fmt.Errorf("unexpected SyncTarget UID %s, expected %s, refusing to sync", syncTarget.UID, cfg.SyncTargetUID)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Resources are accepted as a set to ensure the provision of a
+	// unique set of resources, but all subsequent consumption is via
+	// slice whose entries are assumed to be unique.
+	resources := sets.List[string](cfg.ResourcesToSync)
+
+	// Start api import first because spec and status syncers are blocked by
+	// gvr discovery finding all the configured resource types in the kcp
+	// workspace.
+
+	// kcpImporterInformerFactory only used for apiimport to watch APIResourceImport
+	// TODO(qiujian16) make starting apiimporter optional after we check compatibility of supported APIExports
+	// of synctarget in syncer rather than in server.
+	kcpImporterInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(kcpSyncTargetClient, resyncPeriod)
+	apiImporter, err := NewAPIImporter(
+		cfg.UpstreamConfig, cfg.DownstreamConfig,
+		kcpSyncTargetInformerFactory.Workload().V1alpha1().SyncTargets(),
+		kcpImporterInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
+		resources,
+		cfg.SyncTargetPath, cfg.SyncTargetName, syncTarget.GetUID())
+	if err != nil {
+		return err
+	}
+	kcpImporterInformerFactory.Start(ctx.Done())
+
+	downstreamConfig := rest.CopyConfig(cfg.DownstreamConfig)
+	rest.AddUserAgent(downstreamConfig, "kcp#status-syncer/"+kcpVersion)
+	downstreamDynamicClient, err := dynamic.NewForConfig(downstreamConfig)
+	if err != nil {
+		return err
+	}
+	downstreamKubeClient, err := kubernetes.NewForConfig(downstreamConfig)
+	if err != nil {
+		return err
+	}
+
+	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), cfg.SyncTargetName)
+	logger = logger.WithValues(SyncTargetKey, syncTargetKey)
+	ctx = klog.NewContext(ctx, logger)
+
+	syncTargetGVRSource := synctarget.NewSyncTargetGVRSource(
+		kcpSyncTargetInformerFactory.Workload().V1alpha1().SyncTargets(),
+		downstreamKubeClient,
+	)
+
+	// Check whether we're in the Advanced Scheduling feature-gated mode.
+	advancedSchedulingEnabled := false
+	if syncTarget.GetAnnotations()[AdvancedSchedulingFeatureAnnotation] == "true" {
+		logger.Info("Advanced Scheduling feature is enabled")
+		advancedSchedulingEnabled = true
+	}
+
+	ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(downstreamDynamicClient, nil,
+		func(o *metav1.ListOptions) {
+			o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+		},
+		&filteringGVRSource{
+			syncTargetGVRSource,
+			func(gvr schema.GroupVersionResource) bool {
+				return gvr.Group != kcpcorev1alpha1.SchemeGroupVersion.Group
+			},
+		},
+		cache.Indexers{
+			indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// syncerNamespaceInformerFactory to watch some DNS-related resources in the dns namespace
+	syncerNamespaceInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
+	dnsProcessor := dns.NewDNSProcessor(downstreamKubeClient,
+		syncerNamespaceInformerFactory,
+		cfg.SyncTargetName, syncTarget.GetUID(), syncerNamespace, cfg.DNSImage)
+
+	alwaysRequiredGVRs := []schema.GroupVersionResource{
+		corev1.SchemeGroupVersion.WithResource("secrets"),
+		corev1.SchemeGroupVersion.WithResource("namespaces"),
+	}
+
+	namespaceCleaner := &delegatingCleaner{}
+	shardManager := synctarget.NewShardManager(
+		func(ctx context.Context, shardURLs workloadv1alpha1.VirtualWorkspace) (*synctarget.ShardAccess, func() error, error) {
+			upstreamConfig := rest.CopyConfig(cfg.UpstreamConfig)
+			upstreamConfig.Host = shardURLs.SyncerURL
+			rest.AddUserAgent(upstreamConfig, "kcp#syncing/"+kcpVersion)
+			upstreamSyncerClusterClient, err := kcpdynamic.NewForConfig(upstreamConfig)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			upstreamUpsyncConfig := rest.CopyConfig(cfg.UpstreamConfig)
+			upstreamUpsyncConfig.Host = shardURLs.UpsyncerURL
+			rest.AddUserAgent(upstreamUpsyncConfig, "kcp#upsyncing/"+kcpVersion)
+			upstreamUpsyncerClusterClient, err := kcpdynamic.NewForConfig(upstreamUpsyncConfig)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ddsifForUpstreamSyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(upstreamSyncerClusterClient, nil, nil,
+				&filteringGVRSource{
+					syncTargetGVRSource,
+					func(gvr schema.GroupVersionResource) bool {
+						// Don't expose pods or endpoints via the syncer vw
+						if gvr.Group == corev1.GroupName && (gvr.Resource == "pods") {
+							return false
+						}
+						return true
+					},
+				}, cache.Indexers{})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			ddsifForUpstreamUpsyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(upstreamUpsyncerClusterClient, nil, nil,
+				&filteringGVRSource{
+					syncTargetGVRSource,
+					func(gvr schema.GroupVersionResource) bool {
+						return gvr.Group == corev1.GroupName && (gvr.Resource == "persistentvolumes" ||
+							gvr.Resource == "pods" ||
+							gvr.Resource == "endpoints")
+					},
+				},
+				cache.Indexers{})
+			if err != nil {
+				return nil, nil, err
+			}
+
+			logicalClusterIndex := synctarget.NewLogicalClusterIndex(ddsifForUpstreamSyncer, ddsifForUpstreamUpsyncer)
+
+			secretMutator := mutators.NewSecretMutator()
+			podspecableMutator := mutators.NewPodspecableMutator(
+				func(clusterName logicalcluster.Name) (*ddsif.DiscoveringDynamicSharedInformerFactory, error) {
+					return ddsifForUpstreamSyncer, nil
+				}, syncerNamespaceInformerFactory.Core().V1().Services().Lister(), logicalcluster.From(syncTarget), cfg.SyncTargetName, types.UID(cfg.SyncTargetUID), syncerNamespace, kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.SyncerTunnel))
+
+			logger.Info("Creating spec syncer")
+			specSyncer, err := spec.NewSpecSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, advancedSchedulingEnabled,
+				upstreamSyncerClusterClient, downstreamDynamicClient, downstreamKubeClient, ddsifForUpstreamSyncer, ddsifForDownstream,
+				namespaceCleaner, syncTarget.GetUID(),
+				syncerNamespace, dnsProcessor, cfg.DNSImage, secretMutator, podspecableMutator)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			upsyncerCleaner, err := upsync.NewUpSyncerCleanupController(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, types.UID(cfg.SyncTargetUID), syncTargetKey,
+				upstreamUpsyncerClusterClient, ddsifForUpstreamUpsyncer,
+				ddsifForDownstream)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
+			for _, alwaysRequiredGVR := range alwaysRequiredGVRs {
+				if informer, err := ddsifForUpstreamSyncer.ForResource(alwaysRequiredGVR); err != nil {
+					return nil, nil, err
+				} else {
+					cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+				}
+			}
+
+			start := func() error {
+				// Start and sync informer factories
+
+				ddsifForUpstreamSyncer.Start(ctx.Done())
+				ddsifForUpstreamUpsyncer.Start(ctx.Done())
+
+				if ok := cache.WaitForCacheSync(ctx.Done(), cacheSyncsForAlwaysRequiredGVRs...); !ok {
+					return fmt.Errorf("unable to sync watch caches for virtual workspace %q", shardURLs.SyncerURL)
+				}
+
+				go ddsifForUpstreamSyncer.StartWorker(ctx)
+				go ddsifForUpstreamUpsyncer.StartWorker(ctx)
+
+				go specSyncer.Start(ctx, numSyncerThreads)
+				go upsyncerCleaner.Start(ctx, numSyncerThreads)
+
+				// Create and start GVR-specific controllers through controller managers
+				upstreamSyncerControllerManager := controllermanager.NewControllerManager(ctx,
+					"upstream-syncer",
+					controllermanager.InformerSource{
+						Subscribe: ddsifForUpstreamSyncer.Subscribe,
+						Informers: func() (informers map[schema.GroupVersionResource]cache.SharedIndexInformer, notSynced []schema.GroupVersionResource) {
+							genericInformers, notSynced := ddsifForUpstreamSyncer.Informers()
+							informers = make(map[schema.GroupVersionResource]cache.SharedIndexInformer, len(genericInformers))
+							for gvr, inf := range genericInformers {
+								informers[gvr] = inf.Informer()
+							}
+							return informers, notSynced
+						},
+					},
+					map[string]controllermanager.ManagedController{},
+				)
+				go upstreamSyncerControllerManager.Start(ctx)
+
+				upstreamUpsyncerControllerManager := controllermanager.NewControllerManager(ctx,
+					"upstream-upsyncer",
+					controllermanager.InformerSource{
+						Subscribe: ddsifForUpstreamUpsyncer.Subscribe,
+						Informers: func() (informers map[schema.GroupVersionResource]cache.SharedIndexInformer, notSynced []schema.GroupVersionResource) {
+							genericInformers, notSynced := ddsifForUpstreamUpsyncer.Informers()
+							informers = make(map[schema.GroupVersionResource]cache.SharedIndexInformer, len(genericInformers))
+							for gvr, inf := range genericInformers {
+								informers[gvr] = inf.Informer()
+							}
+							return informers, notSynced
+						},
+					},
+					map[string]controllermanager.ManagedController{},
+				)
+				go upstreamUpsyncerControllerManager.Start(ctx)
+
+				return nil
+			}
+
+			return &synctarget.ShardAccess{
+				SyncerClient:   upstreamSyncerClusterClient,
+				SyncerDDSIF:    ddsifForUpstreamSyncer,
+				UpsyncerClient: upstreamUpsyncerClusterClient,
+				UpsyncerDDSIF:  ddsifForUpstreamUpsyncer,
+
+				LogicalClusterIndex: logicalClusterIndex,
+			}, start, nil
+		},
+	)
+
+	syncTargetController, err := synctarget.NewSyncTargetController(
+		logger,
+		kcpSyncTargetClient.WorkloadV1alpha1().SyncTargets(),
+		kcpSyncTargetInformerFactory.Workload().V1alpha1().SyncTargets(),
+		cfg.SyncTargetName,
+		logicalcluster.From(syncTarget),
+		syncTarget.GetUID(),
+		syncTargetGVRSource,
+		shardManager,
+		func(ctx context.Context, shardURL workloadv1alpha1.TunnelWorkspace) {
+			// Start tunneler for POD access
+			if kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.SyncerTunnel) {
+				upstreamTunnelConfig := rest.CopyConfig(cfg.UpstreamConfig)
+				rest.AddUserAgent(upstreamTunnelConfig, "kcp#tunneler/"+kcpVersion)
+				upstreamTunnelConfig.Host = shardURL.URL
+
+				StartSyncerTunnel(ctx, upstreamTunnelConfig, downstreamConfig, logicalcluster.From(syncTarget), cfg.SyncTargetName, cfg.SyncTargetUID, func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+					informers, _ := ddsifForDownstream.Informers()
+					informer, ok := informers[gvr]
+					if !ok {
+						return nil, fmt.Errorf("failed to get informer for gvr: %s", gvr)
+					}
+					return informer.Lister(), nil
+				})
+			}
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	downstreamNamespaceController, err := namespace.NewDownstreamController(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, syncTarget.GetUID(), downstreamConfig, downstreamDynamicClient, ddsifForDownstream, shardManager.ShardAccessForCluster, syncerNamespace, cfg.DownstreamNamespaceCleanDelay)
+	if err != nil {
+		return err
+	}
+	namespaceCleaner.delegate = downstreamNamespaceController
+
+	secretMutator := mutators.NewSecretMutator()
+	podspecableMutator := mutators.NewPodspecableMutator(
+		func(clusterName logicalcluster.Name) (*ddsif.DiscoveringDynamicSharedInformerFactory, error) {
+			shardAccess, ok, err := shardManager.ShardAccessForCluster(clusterName)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+			}
+			return shardAccess.SyncerDDSIF, nil
+		}, syncerNamespaceInformerFactory.Core().V1().Services().Lister(), logicalcluster.From(syncTarget), cfg.SyncTargetName, types.UID(cfg.SyncTargetUID), syncerNamespace, kcpfeatures.DefaultFeatureGate.Enabled(kcpfeatures.SyncerTunnel))
+
+	logger.Info("Creating spec syncer")
+	specSyncerForDownstream, err := spec.NewSpecSyncerForDownstream(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, advancedSchedulingEnabled,
+		shardManager.ShardAccessForCluster, downstreamDynamicClient, downstreamKubeClient, ddsifForDownstream,
+		namespaceCleaner, syncTarget.GetUID(),
+		syncerNamespace, dnsProcessor, cfg.DNSImage, secretMutator, podspecableMutator)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Creating status syncer")
+	statusSyncer, err := status.NewStatusSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, advancedSchedulingEnabled,
+		shardManager.ShardAccessForCluster, downstreamDynamicClient, ddsifForDownstream, syncTarget.GetUID())
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Creating resource upsyncer")
+	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, shardManager.ShardAccessForCluster, downstreamDynamicClient, ddsifForDownstream, syncTarget.GetUID())
+	if err != nil {
+		return err
+	}
+
+	// Start and sync informer factories
+	var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
+	for _, alwaysRequiredGVR := range alwaysRequiredGVRs {
+		if informer, err := ddsifForDownstream.ForResource(alwaysRequiredGVR); err != nil {
+			return err
+		} else {
+			cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+		}
+	}
+
+	ddsifForDownstream.Start(ctx.Done())
+	kcpSyncTargetInformerFactory.Start(ctx.Done())
+	syncerNamespaceInformerFactory.Start(ctx.Done())
+
+	kcpSyncTargetInformerFactory.WaitForCacheSync(ctx.Done())
+	syncerNamespaceInformerFactory.WaitForCacheSync(ctx.Done())
+	cache.WaitForCacheSync(ctx.Done(), cacheSyncsForAlwaysRequiredGVRs...)
+
+	go ddsifForDownstream.StartWorker(ctx)
+
+	// Start static controllers
+	go apiImporter.Start(klog.NewContext(ctx, logger.WithValues("resources", resources)), importPollInterval)
+	go specSyncerForDownstream.Start(ctx, numSyncerThreads)
+	go statusSyncer.Start(ctx, numSyncerThreads)
+	go upSyncer.Start(ctx, numSyncerThreads)
+	go downstreamNamespaceController.Start(ctx, numSyncerThreads)
+
+	downstreamSyncerControllerManager := controllermanager.NewControllerManager(ctx,
+		"downstream-syncer",
+		controllermanager.InformerSource{
+			Subscribe: ddsifForDownstream.Subscribe,
+			Informers: func() (informers map[schema.GroupVersionResource]cache.SharedIndexInformer, notSynced []schema.GroupVersionResource) {
+				genericInformers, notSynced := ddsifForDownstream.Informers()
+				informers = make(map[schema.GroupVersionResource]cache.SharedIndexInformer, len(genericInformers))
+				for gvr, inf := range genericInformers {
+					informers[gvr] = inf.Informer()
+				}
+				return informers, notSynced
+			},
+		},
+		map[string]controllermanager.ManagedController{
+			endpoints.ControllerName: {
+				RequiredGVRs: []schema.GroupVersionResource{
+					corev1.SchemeGroupVersion.WithResource("services"),
+					corev1.SchemeGroupVersion.WithResource("endpoints"),
+				},
+				Create: func(ctx context.Context) (controllermanager.StartControllerFunc, error) {
+					endpointController, err := endpoints.NewEndpointController(downstreamDynamicClient, ddsifForDownstream, logicalcluster.From(syncTarget), cfg.SyncTargetName, types.UID(cfg.SyncTargetUID))
+					if err != nil {
+						return nil, err
+					}
+					return func(ctx context.Context) {
+						endpointController.Start(ctx, 2)
+					}, nil
+				},
+			},
+		},
+	)
+
+	go syncTargetController.Start(ctx)
+	go downstreamSyncerControllerManager.Start(ctx)
+
+	StartHeartbeat(ctx, kcpSyncTargetClient, cfg.SyncTargetName, cfg.SyncTargetUID)
+
+	return nil
+}
+
+func StartHeartbeat(ctx context.Context, kcpSyncTargetClient kcpclientset.Interface, syncTargetName, syncTargetUID string) {
+	logger := klog.FromContext(ctx)
+
+	// Attempt to heartbeat every interval
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		var heartbeatTime time.Time
+
+		// TODO(marun) Figure out a strategy for backoff to avoid a thundering herd problem with lots of syncers
+		// Attempt to heartbeat every second until successful. Errors are logged instead of being returned so the
+		// poll error can be safely ignored.
+		_ = wait.PollImmediateInfiniteWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+			patchBytes := []byte(fmt.Sprintf(`[{"op":"test","path":"/metadata/uid","value":%q},{"op":"replace","path":"/status/lastSyncerHeartbeatTime","value":%q}]`, syncTargetUID, time.Now().Format(time.RFC3339)))
+			syncTarget, err := kcpSyncTargetClient.WorkloadV1alpha1().SyncTargets().Patch(ctx, syncTargetName, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status")
+			if err != nil {
+				logger.Error(err, "failed to set status.lastSyncerHeartbeatTime")
+				return false, nil
+			}
+
+			heartbeatTime = syncTarget.Status.LastSyncerHeartbeatTime.Time
+			return true, nil
+		})
+		logger.V(5).Info("Heartbeat set", "heartbeatTime", heartbeatTime)
+	}, heartbeatInterval)
+}
+
+type filteringGVRSource struct {
+	ddsif.GVRSource
+	keepGVR func(gvr schema.GroupVersionResource) bool
+}
+
+func (s *filteringGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	gvrs := s.GVRSource.GVRs()
+	filteredGVRs := make(map[schema.GroupVersionResource]ddsif.GVRPartialMetadata, len(gvrs))
+	for gvr, metadata := range gvrs {
+		if !s.keepGVR(gvr) {
+			continue
+		}
+		filteredGVRs[gvr] = metadata
+	}
+	return filteredGVRs
+}
+
+type delegatingCleaner struct {
+	delegate shared.Cleaner
+}
+
+func (s *delegatingCleaner) PlanCleaning(key string) {
+	if s.delegate == nil {
+		return
+	}
+	s.delegate.PlanCleaning(key)
+}
+
+func (s *delegatingCleaner) CancelCleaning(key string) {
+	if s.delegate == nil {
+		return
+	}
+	s.delegate.CancelCleaning(key)
+}

--- a/pkg/syncer/synctarget/gvr_source.go
+++ b/pkg/syncer/synctarget/gvr_source.go
@@ -1,0 +1,343 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctarget
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/informer"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	workloadv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/workload/v1alpha1"
+)
+
+var _ informer.GVRSource = (*syncTargetGVRSource)(nil)
+
+// NewSyncTargetGVRSource returns an [informer.GVRSource] that can update its list of GVRs based on
+// a SyncTarget resource passed to the updateGVRs() method.
+//
+// It will be used to feed the various [informer.DiscoveringDynamicSharedInformerFactory] instances
+// for downstream and upstream.
+func NewSyncTargetGVRSource(
+	syncTargetInformer workloadv1alpha1informers.SyncTargetInformer,
+	downstreamKubeClient *kubernetes.Clientset,
+) *syncTargetGVRSource {
+	return &syncTargetGVRSource{
+		synctargetInformerHasSynced: syncTargetInformer.Informer().HasSynced,
+		gvrsToWatch:                 map[schema.GroupVersionResource]informer.GVRPartialMetadata{},
+		isGVRAllowed: func(ctx context.Context, gvr schema.GroupVersionResource) (bool, error) {
+			if sar, err := downstreamKubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &authorizationv1.SelfSubjectAccessReview{
+				Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{
+						Group:    gvr.Group,
+						Resource: gvr.Resource,
+						Version:  gvr.Version,
+						Verb:     "*",
+					},
+				},
+			}, metav1.CreateOptions{}); err != nil {
+				return false, err
+			} else {
+				return sar.Status.Allowed, nil
+			}
+		},
+		downstreamDiscoveryClient: memory.NewMemCacheClient(discovery.NewDiscoveryClient(downstreamKubeClient.RESTClient())),
+	}
+}
+
+type syncTargetGVRSource struct {
+	gvrsToWatchLock sync.RWMutex
+	gvrsToWatch     map[schema.GroupVersionResource]informer.GVRPartialMetadata
+
+	// Support subscribers that want to know when Synced GVRs have changed.
+	subscribersLock sync.Mutex
+	subscribers     []chan<- struct{}
+
+	synctargetInformerHasSynced cache.InformerSynced
+	isGVRAllowed                func(ctx context.Context, gvr schema.GroupVersionResource) (bool, error)
+
+	downstreamDiscoveryClient discovery.CachedDiscoveryInterface
+}
+
+// GVRs returns the required metadata (scope, kind, singular name) about all GVRs that should be synced.
+// It implements [informer.GVRSource.GVRs].
+func (c *syncTargetGVRSource) GVRs() map[schema.GroupVersionResource]informer.GVRPartialMetadata {
+	c.gvrsToWatchLock.RLock()
+	defer c.gvrsToWatchLock.RUnlock()
+
+	gvrs := make(map[schema.GroupVersionResource]informer.GVRPartialMetadata, len(c.gvrsToWatch)+len(builtinGVRs)+2)
+	gvrs[corev1.SchemeGroupVersion.WithResource("namespaces")] = informer.GVRPartialMetadata{
+		Scope: apiextensionsv1.ClusterScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "namespace",
+			Kind:     "Namespace",
+		},
+	}
+	for key, value := range builtinGVRs {
+		gvrs[key] = value
+	}
+	for key, value := range c.gvrsToWatch {
+		gvrs[key] = value
+	}
+	return gvrs
+}
+
+// Ready returns true if the controller is ready to return the GVRs to sync.
+// It implements [informer.GVRSource.Ready].
+func (c *syncTargetGVRSource) Ready() bool {
+	return c.synctargetInformerHasSynced()
+}
+
+// Subscribe returns a new channel to which the controller writes whenever
+// its list of GVRs has changed.
+// It implements [informer.GVRSource.Subscribe].
+func (c *syncTargetGVRSource) Subscribe() <-chan struct{} {
+	c.subscribersLock.Lock()
+	defer c.subscribersLock.Unlock()
+
+	// Use a buffered channel so we can always send at least 1, regardless of consumer status.
+	changes := make(chan struct{}, 1)
+	c.subscribers = append(c.subscribers, changes)
+
+	return changes
+}
+
+// removeUnusedGVRs removes the GVRs which are not required anymore, and return `true` if GVRs were updated.
+func (c *syncTargetGVRSource) removeUnusedGVRs(ctx context.Context, requiredGVRs map[schema.GroupVersionResource]bool) bool {
+	logger := klog.FromContext(ctx)
+
+	c.gvrsToWatchLock.Lock()
+	defer c.gvrsToWatchLock.Unlock()
+
+	updated := false
+	for gvr := range c.gvrsToWatch {
+		if _, ok := requiredGVRs[gvr]; !ok {
+			logger.WithValues("gvr", gvr.String()).V(2).Info("Stop syncer for gvr")
+			delete(c.gvrsToWatch, gvr)
+			updated = true
+		}
+	}
+	return updated
+}
+
+// addGVR adds the given GVR if it isn't already in the list, and returns `true` if the GVR was added,
+// `false` if it was already there.
+func (c *syncTargetGVRSource) addGVR(ctx context.Context, gvr schema.GroupVersionResource) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	c.gvrsToWatchLock.Lock()
+	defer c.gvrsToWatchLock.Unlock()
+
+	if _, ok := c.gvrsToWatch[gvr]; ok {
+		logger.V(2).Info("Informer is started already")
+		return false, nil
+	}
+
+	partialMetadata, err := c.getGVRPartialMetadata(gvr)
+	if err != nil {
+		return false, err
+	}
+
+	c.gvrsToWatch[gvr] = *partialMetadata
+
+	return true, nil
+}
+
+func (c *syncTargetGVRSource) getGVRPartialMetadata(gvr schema.GroupVersionResource) (*informer.GVRPartialMetadata, error) {
+	apiResourceList, err := c.downstreamDiscoveryClient.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+	if err != nil {
+		return nil, err
+	}
+	for _, apiResource := range apiResourceList.APIResources {
+		if apiResource.Name == gvr.Resource {
+			var resourceScope apiextensionsv1.ResourceScope
+			if apiResource.Namespaced {
+				resourceScope = apiextensionsv1.NamespaceScoped
+			} else {
+				resourceScope = apiextensionsv1.ClusterScoped
+			}
+
+			return &informer.GVRPartialMetadata{
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind:     apiResource.Kind,
+						Singular: apiResource.SingularName,
+					},
+					Scope: resourceScope,
+				},
+				nil
+		}
+	}
+	return nil, fmt.Errorf("unable to retrieve discovery for GVR: %s", gvr)
+}
+
+func (c *syncTargetGVRSource) notifySubscribers(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	c.subscribersLock.Lock()
+	defer c.subscribersLock.Unlock()
+
+	for index, ch := range c.subscribers {
+		logger.V(4).Info("Attempting to notify subscribers", "index", index)
+		select {
+		case ch <- struct{}{}:
+			logger.V(4).Info("Successfully notified subscriber", "index", index)
+		default:
+			logger.V(4).Info("Unable to notify subscriber - channel full", "index", index)
+		}
+	}
+}
+
+var builtinGVRs = map[schema.GroupVersionResource]informer.GVRPartialMetadata{
+	{
+		Version:  "v1",
+		Resource: "configmaps",
+	}: {
+		Scope: apiextensionsv1.NamespaceScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "configMap",
+			Kind:     "configmap",
+		},
+	},
+	{
+		Version:  "v1",
+		Resource: "secrets",
+	}: {
+		Scope: apiextensionsv1.NamespaceScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "secret",
+			Kind:     "Secret",
+		},
+	},
+}
+
+func getAllGVRs(synctarget *workloadv1alpha1.SyncTarget) map[schema.GroupVersionResource]bool {
+	// TODO(jmprusi): Added Configmaps and Secrets to the default syncing, but we should figure out
+	//                a way to avoid doing that: https://github.com/kcp-dev/kcp/issues/727
+	gvrs := map[schema.GroupVersionResource]bool{}
+
+	for gvr := range builtinGVRs {
+		gvrs[gvr] = true
+	}
+
+	if synctarget == nil {
+		return gvrs
+	}
+
+	// TODO(qiujian16) We currently checks the API compatibility on the server side. When we change to check the
+	// compatibility on the syncer side, this part needs to be changed.
+	for _, r := range synctarget.Status.SyncedResources {
+		if r.State != workloadv1alpha1.ResourceSchemaAcceptedState {
+			continue
+		}
+		for _, version := range r.Versions {
+			gvrs[schema.GroupVersionResource{
+				Group:    r.Group,
+				Version:  version,
+				Resource: r.Resource,
+			}] = true
+		}
+	}
+
+	return gvrs
+}
+
+func (c *syncTargetGVRSource) reconcile(ctx context.Context, syncTarget *workloadv1alpha1.SyncTarget) (reconcileStatus, error) {
+	logger := klog.FromContext(ctx)
+
+	requiredGVRs := getAllGVRs(syncTarget)
+
+	c.downstreamDiscoveryClient.Invalidate()
+
+	notify := false
+	var unauthorizedGVRs []string
+	var errs []error
+	for gvr := range requiredGVRs {
+		logger := logger.WithValues("gvr", gvr.String())
+		ctx := klog.NewContext(ctx, logger)
+		allowed, err := c.isGVRAllowed(ctx, gvr)
+		if err != nil {
+			logger.Error(err, "Failed to check ssar")
+			errs = append(errs, err)
+			unauthorizedGVRs = append(unauthorizedGVRs, gvr.String())
+			continue
+		}
+
+		if !allowed {
+			logger.V(2).Info("Stop informer since the syncer is not authorized to sync")
+			// remove this from requiredGVRs so its informer will be stopped later.
+			delete(requiredGVRs, gvr)
+			unauthorizedGVRs = append(unauthorizedGVRs, gvr.String())
+			continue
+		}
+
+		if updated, err := c.addGVR(ctx, gvr); err != nil {
+			errs = append(errs, err)
+			continue
+		} else if updated {
+			notify = true
+		}
+	}
+
+	if updated := c.removeUnusedGVRs(ctx, requiredGVRs); updated {
+		notify = true
+	}
+
+	if notify {
+		c.notifySubscribers(ctx)
+	}
+
+	if syncTarget == nil {
+		return reconcileStatusContinue, utilserrors.NewAggregate(errs)
+	}
+
+	oldCondition := conditions.Get(syncTarget, workloadv1alpha1.SyncerAuthorized).DeepCopy()
+	if len(unauthorizedGVRs) > 0 {
+		conditions.MarkFalse(
+			syncTarget,
+			workloadv1alpha1.SyncerAuthorized,
+			"SyncerUnauthorized",
+			conditionsv1alpha1.ConditionSeverityError,
+			"SSAR check failed for gvrs: %s", strings.Join(unauthorizedGVRs, ";"),
+		)
+	} else {
+		conditions.MarkTrue(syncTarget, workloadv1alpha1.SyncerAuthorized)
+	}
+	newCondition := conditions.Get(syncTarget, workloadv1alpha1.SyncerAuthorized)
+
+	if equality.Semantic.DeepEqual(oldCondition, newCondition) {
+		return reconcileStatusContinue, utilserrors.NewAggregate(errs)
+	}
+
+	return reconcileStatusStopAndRequeue, utilserrors.NewAggregate(errs)
+}

--- a/pkg/syncer/synctarget/shard_manager.go
+++ b/pkg/syncer/synctarget/shard_manager.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctarget
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/informer"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+// NewLogicalClusterIndex creates an index that contains all the keys of the synced and upsynced resources,
+// indexed by logical cluster name.
+// This index is filled by the syncer and upsyncer ddsifs, and is used to check if the related shard contains
+// a given logicalCluster.
+func NewLogicalClusterIndex(syncerDDSIF, upsyncerDDSIF *informer.DiscoveringDynamicSharedInformerFactory) *logicalClusterIndex {
+	index := &logicalClusterIndex{
+		indexedKeys:     map[string]map[string]interface{}{},
+		indexedKeysLock: sync.RWMutex{},
+	}
+
+	clusterNameAndKey := func(syncerSource string, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) (clusterName, clusterKeys string, err error) {
+		clusterName = logicalcluster.From(obj).String()
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+		if err != nil {
+			return "", "", err
+		}
+
+		return clusterName, fmt.Sprintf("%s$$%s.%s.%s##%s", syncerSource, gvr.Resource, gvr.Group, gvr.Version, key), nil
+	}
+
+	add := func(syncerSource string, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) error {
+		clusterName, clusterKey, err := clusterNameAndKey(syncerSource, gvr, obj)
+		if err != nil {
+			return err
+		}
+
+		index.indexedKeysLock.Lock()
+		defer index.indexedKeysLock.Unlock()
+
+		clusterKeys, ok := index.indexedKeys[clusterName]
+		if !ok {
+			clusterKeys = map[string]interface{}{}
+			index.indexedKeys[clusterName] = clusterKeys
+		}
+		clusterKeys[clusterKey] = nil
+		return nil
+	}
+
+	delete := func(syncerSource string, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) error {
+		clusterName, clusterKey, err := clusterNameAndKey(syncerSource, gvr, obj)
+		if err != nil {
+			return err
+		}
+
+		index.indexedKeysLock.Lock()
+		defer index.indexedKeysLock.Unlock()
+
+		clusterKeys, ok := index.indexedKeys[clusterName]
+		if !ok {
+			return nil
+		}
+		delete(clusterKeys, clusterKey)
+		if len(clusterKeys) == 0 {
+			delete(index.indexedKeys, clusterName)
+		}
+		return nil
+	}
+
+	syncerDDSIF.AddEventHandler(informer.GVREventHandlerFuncs{
+		AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			_ = add("S", gvr, obj.(*unstructured.Unstructured))
+		},
+		DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			_ = add("S", gvr, obj.(*unstructured.Unstructured))
+		},
+	})
+
+	upsyncerDDSIF.AddEventHandler(informer.GVREventHandlerFuncs{
+		AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			_ = delete("U", gvr, obj.(*unstructured.Unstructured))
+		},
+		DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			_ = delete("U", gvr, obj.(*unstructured.Unstructured))
+		},
+	})
+
+	return index
+}
+
+// Exists returns true if the logicalClusterIndex contains at least one value
+// for the given clusterName.
+func (index *logicalClusterIndex) Exists(clusterName logicalcluster.Name) bool {
+	index.indexedKeysLock.Lock()
+	defer index.indexedKeysLock.Unlock()
+
+	_, ok := index.indexedKeys[string(clusterName)]
+	return ok
+}
+
+type logicalClusterIndex struct {
+	indexedKeys     map[string]map[string]interface{}
+	indexedKeysLock sync.RWMutex
+}
+
+// ShardAccess contains clustered dynamic clients, as well as
+// cluster-aware informer factories for both the Syncer and Upsyncer virtual workspaces
+// associated to a Shard.
+type ShardAccess struct {
+	SyncerClient   kcpdynamic.ClusterInterface
+	SyncerDDSIF    *informer.DiscoveringDynamicSharedInformerFactory
+	UpsyncerClient kcpdynamic.ClusterInterface
+	UpsyncerDDSIF  *informer.DiscoveringDynamicSharedInformerFactory
+
+	// LogicalClusterIndex contains all the keys of the synced and upsynced resources
+	// indexed by logical cluster name.
+	LogicalClusterIndex *logicalClusterIndex
+}
+
+// GetShardAccessFunc is the type of a function that provide a [ShardAccess] from a
+// logical cluster name.
+type GetShardAccessFunc func(clusterName logicalcluster.Name) (ShardAccess, bool, error)
+
+// NewShardManager returns a [ShardManager] that can manage the addition or removal of shard-specific
+// upstream virtual workspace URLs, based on a SyncTarget resource passed to the updateShards() method.
+//
+// When a shard is found (identified by the couple of virtual workspace URLs - for both syncer and upsyncer),
+// then the newShardControllers() method is called, the resulting [ShardAccess] is stored,
+// and the resulting start() function is called in a goroutine.
+//
+// When a shard is removed, the context initially passed to the
+// startShardControllers() method is cancelled.
+//
+// The ShardAccessForCluster() method will be used by some downstream controllers in order to
+// be able to get / list upstream resources in the right shard.
+func NewShardManager(
+	newShardControllers func(ctx context.Context, shardURLs workloadv1alpha1.VirtualWorkspace) (acces *ShardAccess, start func() error, err error)) *shardManager {
+	return &shardManager{
+		controllers:         map[workloadv1alpha1.VirtualWorkspace]shardControllers{},
+		newShardControllers: newShardControllers,
+	}
+}
+
+type shardManager struct {
+	controllersLock     sync.RWMutex
+	controllers         map[workloadv1alpha1.VirtualWorkspace]shardControllers
+	newShardControllers func(ctx context.Context, shardURLs workloadv1alpha1.VirtualWorkspace) (acces *ShardAccess, start func() error, err error)
+}
+
+func (c *shardManager) ShardAccessForCluster(clusterName logicalcluster.Name) (ShardAccess, bool, error) {
+	c.controllersLock.RLock()
+	defer c.controllersLock.RUnlock()
+
+	for _, shardControllers := range c.controllers {
+		if shardControllers.ShardAccess.LogicalClusterIndex.Exists(clusterName) {
+			return shardControllers.ShardAccess, true, nil
+		}
+	}
+	return ShardAccess{}, false, nil
+}
+
+func (c *shardManager) reconcile(ctx context.Context, syncTarget *workloadv1alpha1.SyncTarget) (reconcileStatus, error) {
+	logger := klog.FromContext(ctx)
+
+	requiredShards := map[workloadv1alpha1.VirtualWorkspace]bool{}
+	if syncTarget != nil {
+		for _, shardURLs := range syncTarget.Status.VirtualWorkspaces {
+			requiredShards[shardURLs] = true
+		}
+	}
+
+	c.controllersLock.Lock()
+	defer c.controllersLock.Unlock()
+
+	// Remove obsolete controllers that don't have a shard anymore
+	for shardURLs, shardControllers := range c.controllers {
+		if _, ok := requiredShards[shardURLs]; ok {
+			// The controllers are still expected => don't remove them
+			continue
+		}
+		// The controllers should not be running
+		// Stop them and remove it from the list of started shard controllers
+		shardControllers.stop()
+		delete(c.controllers, shardURLs)
+	}
+
+	var errs []error
+	// Create and start missing controllers that have Virtual Workspace URLs for a shard
+	for shardURLs := range requiredShards {
+		shardURLs := shardURLs
+		if _, ok := c.controllers[shardURLs]; ok {
+			// The controllers are already started
+			continue
+		}
+
+		// Start the controllers
+		shardControllersContext, cancelFunc := context.WithCancel(ctx)
+		// Create the controllers
+		shardAccess, start, err := c.newShardControllers(shardControllersContext, shardURLs)
+		if err != nil {
+			logger.Error(err, "failed creating controllers for shard", "shard", shardURLs)
+			errs = append(errs, err)
+			cancelFunc()
+			continue
+		}
+		c.controllers[shardURLs] = shardControllers{
+			*shardAccess, cancelFunc, false,
+		}
+		go func() {
+			err := start()
+			c.controllersLock.Lock()
+			defer c.controllersLock.Unlock()
+
+			if err != nil {
+				delete(c.controllers, shardURLs)
+				cancelFunc()
+			} else {
+				controllers := c.controllers[shardURLs]
+				controllers.ready = true
+				c.controllers[shardURLs] = controllers
+			}
+		}()
+	}
+	return reconcileStatusContinue, utilserrors.NewAggregate(errs)
+}
+
+type shardControllers struct {
+	ShardAccess
+	stop  func()
+	ready bool
+}

--- a/pkg/syncer/synctarget/synctarget_controller.go
+++ b/pkg/syncer/synctarget/synctarget_controller.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctarget
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/committer"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	workloadv1alpha1client "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/typed/workload/v1alpha1"
+	workloadv1alpha1informers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions/workload/v1alpha1"
+	workloadv1alpha1listers "github.com/kcp-dev/kcp/sdk/client/listers/workload/v1alpha1"
+)
+
+const (
+	resyncPeriod   = 10 * time.Hour
+	controllerName = "kcp-syncer-synctarget-gvrsource-controller"
+)
+
+type controller struct {
+	queue workqueue.RateLimitingInterface
+
+	syncTargetUID    types.UID
+	syncTargetLister workloadv1alpha1listers.SyncTargetLister
+	commit           CommitFunc
+
+	reconcilers []reconciler
+}
+
+// NewSyncTargetController returns a controller that watches the [workloadv1alpha1.SyncTarget]
+// associated to this syncer.
+// It then calls the update methods on the shardManager and gvrSource
+// that were passed in arguments, to update available shards and GVRs
+// according to the content of the SyncTarget status.
+func NewSyncTargetController(
+	syncerLogger logr.Logger,
+	syncTargetClient workloadv1alpha1client.SyncTargetInterface,
+	syncTargetInformer workloadv1alpha1informers.SyncTargetInformer,
+	syncTargetName string,
+	syncTargetClusterName logicalcluster.Name,
+	syncTargetUID types.UID,
+	gvrSource *syncTargetGVRSource,
+	shardManager *shardManager,
+	startShardTunneler func(ctx context.Context, shardURL workloadv1alpha1.TunnelWorkspace),
+) (*controller, error) {
+	c := &controller{
+		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		syncTargetUID:    syncTargetUID,
+		syncTargetLister: syncTargetInformer.Lister(),
+		commit:           committer.NewCommitterScoped[*SyncTarget, Patcher, *SyncTargetSpec, *SyncTargetStatus](syncTargetClient),
+
+		reconcilers: []reconciler{
+			gvrSource,
+			shardManager,
+			&tunnelerReconciler{
+				startedTunnelers:   make(map[workloadv1alpha1.TunnelWorkspace]tunnelerStopper),
+				startShardTunneler: startShardTunneler,
+			},
+		},
+	}
+
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	_, _ = syncTargetInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err != nil {
+				return false
+			}
+			_, name, err := cache.SplitMetaNamespaceKey(key)
+			if err != nil {
+				return false
+			}
+			return name == syncTargetName
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { c.enqueue(obj, logger) },
+			UpdateFunc: func(old, obj interface{}) { c.enqueue(obj, logger) },
+			DeleteFunc: func(obj interface{}) { c.enqueue(obj, logger) },
+		},
+	})
+
+	return c, nil
+}
+
+type SyncTarget = workloadv1alpha1.SyncTarget
+type SyncTargetSpec = workloadv1alpha1.SyncTargetSpec
+type SyncTargetStatus = workloadv1alpha1.SyncTargetStatus
+type Patcher = workloadv1alpha1client.SyncTargetInterface
+type Resource = committer.Resource[*SyncTargetSpec, *SyncTargetStatus]
+type CommitFunc = func(context.Context, *Resource, *Resource) error
+
+func (c *controller) enqueue(obj interface{}, logger logr.Logger) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(2).Info("queueing SyncTarget")
+
+	c.queue.Add(key)
+}
+
+// Start starts the controller worker.
+func (c *controller) Start(ctx context.Context) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if requeue, err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("failed to sync %q: %w", key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if requeue {
+		// only requeue if we didn't error, but we still want to requeue
+		c.queue.Add(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, key string) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "failed to split key, dropping")
+		return false, nil
+	}
+
+	syncTarget, err := c.syncTargetLister.Get(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	if apierrors.IsNotFound(err) || syncTarget.GetUID() != c.syncTargetUID {
+		return c.reconcile(ctx, nil)
+	}
+
+	previous := syncTarget
+	syncTarget = syncTarget.DeepCopy()
+
+	var errs []error
+	requeue, err := c.reconcile(ctx, syncTarget)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	oldResource := &Resource{ObjectMeta: previous.ObjectMeta, Spec: &previous.Spec, Status: &previous.Status}
+	newResource := &Resource{ObjectMeta: syncTarget.ObjectMeta, Spec: &syncTarget.Spec, Status: &syncTarget.Status}
+	if err := c.commit(ctx, oldResource, newResource); err != nil {
+		errs = append(errs, err)
+	}
+
+	return requeue, errors.NewAggregate(errs)
+}

--- a/pkg/syncer/synctarget/synctarget_reconciler.go
+++ b/pkg/syncer/synctarget/synctarget_reconciler.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctarget
+
+import (
+	"context"
+
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+type reconcileStatus int
+
+const (
+	reconcileStatusStopAndRequeue reconcileStatus = iota
+	reconcileStatusContinue
+)
+
+type reconciler interface {
+	reconcile(ctx context.Context, syncTarget *workloadv1alpha1.SyncTarget) (reconcileStatus, error)
+}
+
+func (c *controller) reconcile(ctx context.Context, syncTarget *workloadv1alpha1.SyncTarget) (bool, error) {
+	var errs []error
+
+	requeue := false
+	for _, r := range c.reconcilers {
+		var err error
+		var status reconcileStatus
+		status, err = r.reconcile(ctx, syncTarget)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if status == reconcileStatusStopAndRequeue {
+			requeue = true
+			break
+		}
+	}
+
+	return requeue, utilserrors.NewAggregate(errs)
+}

--- a/pkg/syncer/synctarget/tunneler_reconciler.go
+++ b/pkg/syncer/synctarget/tunneler_reconciler.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package synctarget
+
+import (
+	"context"
+	"sync"
+
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+type tunnelerReconciler struct {
+	startedTunnelersLock sync.RWMutex
+	startedTunnelers     map[workloadv1alpha1.TunnelWorkspace]tunnelerStopper
+
+	startShardTunneler func(ctx context.Context, shardURL workloadv1alpha1.TunnelWorkspace)
+}
+
+func (c *tunnelerReconciler) reconcile(ctx context.Context, syncTarget *workloadv1alpha1.SyncTarget) (reconcileStatus, error) {
+	requiredShards := map[workloadv1alpha1.TunnelWorkspace]bool{}
+	if syncTarget != nil {
+		for _, shardURL := range syncTarget.Status.TunnelWorkspaces {
+			requiredShards[shardURL] = true
+		}
+	}
+
+	c.startedTunnelersLock.Lock()
+	defer c.startedTunnelersLock.Unlock()
+
+	// Remove obsolete tunnelers that don't have a shard anymore
+	for shardURL, stopTunneler := range c.startedTunnelers {
+		if _, ok := requiredShards[shardURL]; ok {
+			// The tunnelers are still expected => don't remove them
+			continue
+		}
+		// The tunnelers should not be running
+		// Stop them and remove it from the list of started shard tunneler
+		stopTunneler()
+		delete(c.startedTunnelers, shardURL)
+	}
+
+	var errs []error
+	// Create and start missing tunnelers
+	for shardURL := range requiredShards {
+		if _, ok := c.startedTunnelers[shardURL]; ok {
+			// The tunnelers are already started
+			continue
+		}
+
+		// Start the tunnelers
+		shardTunnelerContext, cancelFunc := context.WithCancel(ctx)
+
+		// Create the tunneler
+		c.startShardTunneler(shardTunnelerContext, shardURL)
+		c.startedTunnelers[shardURL] = tunnelerStopper(cancelFunc)
+	}
+	return reconcileStatusContinue, utilserrors.NewAggregate(errs)
+}
+
+type tunnelerStopper func()

--- a/pkg/syncer/tunneler.go
+++ b/pkg/syncer/tunneler.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/kcp/pkg/tunneler"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var (
+	errorScheme = runtime.NewScheme()
+	errorCodecs = serializer.NewCodecFactory(errorScheme)
+)
+
+func init() {
+	errorScheme.AddUnversionedTypes(metav1.Unversioned,
+		&metav1.Status{},
+	)
+}
+
+type ResourceListerFunc func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+
+// StartSyncerTunnel blocks until the context is cancelled trying to establish a tunnel against the specified target.
+func StartSyncerTunnel(ctx context.Context, upstream, downstream *rest.Config, syncTargetWorkspace logicalcluster.Name, syncTargetName, syncTargetUID string, getDownstreamLister ResourceListerFunc) {
+	// connect to create the reverse tunnels
+	var (
+		initBackoff   = 5 * time.Second
+		maxBackoff    = 5 * time.Minute
+		resetDuration = 1 * time.Minute
+		backoffFactor = 2.0
+		jitter        = 1.0
+		clock         = &clock.RealClock{}
+		sliding       = true
+	)
+
+	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
+	logger := klog.FromContext(ctx)
+
+	go wait.BackoffUntil(func() {
+		logger.V(5).Info("starting tunnel")
+		err := startTunneler(ctx, upstream, downstream, syncTargetWorkspace, syncTargetName, syncTargetUID, getDownstreamLister)
+		if err != nil {
+			logger.Error(err, "failed to create tunnel")
+		}
+	}, backoffMgr, sliding, ctx.Done())
+}
+
+func startTunneler(ctx context.Context, upstream, downstream *rest.Config, syncTargetClusterName logicalcluster.Name, syncTargetName, syncTargetUID string, getDownstreamLister ResourceListerFunc) error {
+	logger := klog.FromContext(ctx)
+
+	// syncer --> kcp
+	clientUpstream, err := rest.HTTPClientFor(upstream)
+	if err != nil {
+		return err
+	}
+
+	cfg := *downstream
+	// use http/1.1 to allow SPDY tunneling: pod exec, port-forward, ...
+	cfg.NextProtos = []string{"http/1.1"}
+	// syncer --> local apiserver
+	url, err := url.Parse(cfg.Host)
+	if err != nil {
+		return err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	if err != nil {
+		return err
+	}
+
+	clientDownstream, err := rest.HTTPClientFor(&cfg)
+	if err != nil {
+		return err
+	}
+
+	proxy.Transport = clientDownstream.Transport
+
+	// create the reverse connection
+	// virtual workspaces
+	u, err := url.Parse(upstream.Host)
+	if err != nil {
+		return err
+	}
+	// strip the path
+	u.Path = ""
+	dst, err := tunneler.SyncerTunnelURL(u.String(), syncTargetClusterName.String(), syncTargetName)
+	if err != nil {
+		return err
+	}
+
+	logger = logger.WithValues("syncer-tunnel-url", dst)
+	logger.Info("connecting to destination URL")
+	l, err := tunneler.NewListener(clientUpstream, dst)
+	if err != nil {
+		return err
+	}
+	defer l.Close()
+
+	// reverse proxy the request coming from the reverse connection to the p-cluster apiserver
+	server := &http.Server{ReadHeaderTimeout: 30 * time.Second, Handler: withPodAccessCheck(proxy, getDownstreamLister, syncTargetClusterName, syncTargetName, syncTargetUID)}
+	defer server.Close()
+
+	logger.V(2).Info("serving on reverse connection")
+	errCh := make(chan error)
+	go func() {
+		errCh <- server.Serve(l)
+	}()
+
+	select {
+	case err = <-errCh:
+	case <-ctx.Done():
+		err = server.Close()
+	}
+	logger.V(2).Info("stop serving on reverse connection")
+	return err
+}
+
+func withPodAccessCheck(handler http.Handler, getDownstreamLister ResourceListerFunc, synctargetClusterName logicalcluster.Name, synctargetName, syncTargetUID string) http.HandlerFunc {
+	namespaceGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		resolver := requestinfo.NewKCPRequestInfoResolver()
+		requestInfo, err := resolver.NewRequestInfo(req)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				errors.NewInternalError(fmt.Errorf("could not resolve RequestInfo: %w", err)),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		// Ensure that requests are only for pods, and we have the required information, if not, return false.
+		if requestInfo.Resource != "pods" || requestInfo.Subresource == "" || requestInfo.Name == "" || requestInfo.Namespace == "" {
+			responsewriters.ErrorNegotiated(
+				errors.NewForbidden(podGVR.GroupResource(), requestInfo.Name, fmt.Errorf("invalid resource and/or subresource")),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		// Ensure that requests are only for pods in a namespace owned by this syncer, if not, return false.
+		downstreamNamespaceName := requestInfo.Namespace
+
+		nsInformer, err := getDownstreamLister(namespaceGVR)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				errors.NewInternalError(fmt.Errorf("error while getting downstream namespace lister: %w", err)),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		obj, err := nsInformer.Get(downstreamNamespaceName)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				errors.NewForbidden(namespaceGVR.GroupResource(), requestInfo.Namespace, fmt.Errorf("forbidden")),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		downstreamNs, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			responsewriters.ErrorNegotiated(
+				errors.NewInternalError(fmt.Errorf("namespace resource should be *unstructured.Unstructured but was: %T", obj)),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		// Ensure the referenced downstream namespace locator is correct and owned by this syncer.
+		annotations := downstreamNs.GetAnnotations()
+		if locator, ok, err := shared.LocatorFromAnnotations(annotations); ok {
+			if err != nil || locator.SyncTarget.Name != synctargetName || string(locator.SyncTarget.UID) != syncTargetUID || locator.SyncTarget.ClusterName != string(synctargetClusterName) {
+				responsewriters.ErrorNegotiated(
+					errors.NewForbidden(podGVR.GroupResource(), requestInfo.Name, fmt.Errorf("forbidden")),
+					errorCodecs, schema.GroupVersion{}, w, req,
+				)
+				return
+			}
+		} else {
+			responsewriters.ErrorNegotiated(
+				errors.NewForbidden(podGVR.GroupResource(), requestInfo.Name, fmt.Errorf("forbidden")),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		// Ensure Pod is in Upsynced state.
+		podName := requestInfo.Name
+		podInformer, err := getDownstreamLister(podGVR)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				errors.NewInternalError(fmt.Errorf("error while getting pod lister: %w", err)),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+		obj, err = podInformer.ByNamespace(downstreamNamespaceName).Get(podName)
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				errors.NewForbidden(podGVR.GroupResource(), requestInfo.Name, fmt.Errorf("forbidden")),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+		if downstreamPod, ok := obj.(*unstructured.Unstructured); ok {
+			if downstreamPod.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+workloadv1alpha1.ToSyncTargetKey(synctargetClusterName, synctargetName)] != string(workloadv1alpha1.ResourceStateUpsync) {
+				responsewriters.ErrorNegotiated(
+					errors.NewForbidden(podGVR.GroupResource(), requestInfo.Name, fmt.Errorf("forbidden")),
+					errorCodecs, schema.GroupVersion{}, w, req,
+				)
+				return
+			}
+		} else {
+			responsewriters.ErrorNegotiated(
+				errors.NewInternalError(fmt.Errorf("pod resource should be *unstructured.Unstructured but was: %T", obj)),
+				errorCodecs, schema.GroupVersion{}, w, req,
+			)
+			return
+		}
+
+		handler.ServeHTTP(w, req)
+	}
+}

--- a/pkg/syncer/tunneler_test.go
+++ b/pkg/syncer/tunneler_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+func Test_withPodAccessCheck(t *testing.T) {
+	tests := []struct {
+		name                  string
+		podState              string
+		subresource           string
+		synctargetClusterName string
+		synctargetName        string
+		syncTargetUID         string
+		expectedStatusCode    int
+		requestPath           string
+	}{
+		{
+			name:                  "valid pod and valid namespace, expect success",
+			expectedStatusCode:    http.StatusOK,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/pods/test-pod/log",
+		},
+		{
+			name:                  "pod not in upsync state, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/pods/test-pod/log",
+		},
+		{
+			name:                  "namespace not owned by the syncer, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-another-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/pods/test-pod/log",
+		},
+		{
+			name:                  "non existent pod, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/pods/not-existing-pod/log",
+		},
+		{
+			name:                  "non existent namespace, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/not-existing-namespace/pods/test-pod/log",
+		},
+		{
+			name:                  "request is not for a pod, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/configmaps/test-pod/status",
+		},
+		{
+			name:                  "request doesn't contain a subresource, expect 403",
+			expectedStatusCode:    http.StatusForbidden,
+			podState:              "Upsync",
+			synctargetName:        "test-synctarget",
+			syncTargetUID:         "test-uid",
+			synctargetClusterName: "test-workspace",
+			requestPath:           "/api/v1/namespaces/test-namespace/pods/test-pod",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+
+			fakeDownstreamInformers := map[schema.GroupVersionResource]cache.GenericLister{}
+			fakeDownstreamInformers[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}] = &fakeLister{
+				objs: []runtime.Object{
+					&corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "test-namespace",
+							Labels: map[string]string{
+								workloadv1alpha1.ClusterResourceStateLabelPrefix + workloadv1alpha1.ToSyncTargetKey(logicalcluster.Name(tt.synctargetClusterName), tt.synctargetName): tt.podState,
+							},
+						},
+					},
+				},
+			}
+			locator, err := json.Marshal(shared.NamespaceLocator{
+				SyncTarget: shared.SyncTargetLocator{
+					Name:        "test-synctarget",
+					UID:         "test-uid",
+					ClusterName: "test-workspace",
+				},
+				ClusterName: "test-workspace",
+				Namespace:   "test-namespace",
+			})
+			require.NoError(t, err)
+
+			fakeDownstreamInformers[schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}] = &fakeLister{
+				objs: []runtime.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+							Annotations: map[string]string{
+								shared.NamespaceLocatorAnnotation: string(locator),
+							},
+						},
+					},
+				},
+			}
+
+			synctargetWorkspaceName, _ := logicalcluster.NewPath(tt.synctargetClusterName).Name()
+			handler := withPodAccessCheck(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+				func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+					return fakeDownstreamInformers[gvr], nil
+				},
+				synctargetWorkspaceName, tt.synctargetName, tt.syncTargetUID)
+
+			request := httptest.NewRequest(http.MethodGet, tt.requestPath, nil)
+			handler.ServeHTTP(rw, request)
+
+			require.Equal(t, tt.expectedStatusCode, rw.Code)
+		})
+	}
+}
+
+type fakeLister struct {
+	objs []runtime.Object
+}
+
+func (f *fakeLister) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	return f.objs, nil
+}
+
+func (f *fakeLister) Get(name string) (ret runtime.Object, err error) {
+	for _, obj := range f.objs {
+		// return the unstructured object if the name matches
+		if obj.(metav1.Object).GetName() == name {
+			unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+			if err != nil {
+				return nil, err
+			}
+			return &unstructured.Unstructured{Object: unstructuredObj}, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{}, name)
+}
+
+func (f *fakeLister) ByIndex(indexName, indexKey string) (ret []interface{}, err error) {
+	panic("implement me")
+}
+
+func (f *fakeLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	for f.objs[0].(metav1.Object).GetNamespace() == namespace {
+		return f
+	}
+	return nil
+}

--- a/pkg/syncer/upsync/upsync_cleanup_controller.go
+++ b/pkg/syncer/upsync/upsync_cleanup_controller.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	syncerindexers "github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+const cleanupControllerName = "kcp-resource-upsyncer-cleanup"
+
+// NewUpSyncerCleanupController returns a new controller which will cleanup any upsynced upstream resource
+// if the corresponding downstream resources doesn't exist.
+func NewUpSyncerCleanupController(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name,
+	syncTargetName string, syncTargetUID types.UID, syncTargetKey string,
+	upstreamClusterClient kcpdynamic.ClusterInterface,
+	ddsifForUpstreamUpsyncer *ddsif.DiscoveringDynamicSharedInformerFactory,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+) (*cleanupController, error) {
+	c := &cleanupController{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), cleanupControllerName),
+		cleanupReconciler: cleanupReconciler{
+			getUpstreamClient: func(clusterName logicalcluster.Name) (dynamic.Interface, error) {
+				return upstreamClusterClient.Cluster(clusterName.Path()), nil
+			},
+			getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+				informers, notSynced := ddsifForDownstream.Informers()
+				informer, ok := informers[gvr]
+				if !ok {
+					if shared.ContainsGVR(notSynced, gvr) {
+						return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+					}
+					return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+				}
+				return informer.Lister(), nil
+			},
+			listDownstreamNamespacesByLocator: func(jsonLocator string) ([]*unstructured.Unstructured, error) {
+				nsInformer, err := ddsifForDownstream.ForResource(namespaceGVR)
+				if err != nil {
+					return nil, err
+				}
+				return indexers.ByIndex[*unstructured.Unstructured](nsInformer.Informer().GetIndexer(), syncerindexers.ByNamespaceLocatorIndexName, jsonLocator)
+			},
+
+			syncTargetName:        syncTargetName,
+			syncTargetClusterName: syncTargetClusterName,
+			syncTargetUID:         syncTargetUID,
+		},
+	}
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	ddsifForUpstreamUpsyncer.AddEventHandler(ddsif.GVREventHandlerFuncs{
+		AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if gvr == namespaceGVR {
+				return
+			}
+			c.enqueue(gvr, obj, logger)
+		},
+	})
+
+	return c, nil
+}
+
+type cleanupController struct {
+	queue workqueue.RateLimitingInterface
+
+	cleanupReconciler
+}
+
+func (c *cleanupController) enqueue(gvr schema.GroupVersionResource, obj interface{}, logger logr.Logger) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	logging.WithQueueKey(logger, key).V(2).Info("queueing", "gvr", gvr.String())
+	queueKey := queueKey{
+		gvr: gvr,
+		key: key,
+	}
+
+	c.queue.Add(queueKey)
+}
+
+func (c *cleanupController) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting upsync workers")
+	defer logger.Info("Stopping upsync workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+func (c *cleanupController) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *cleanupController) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(queueKey)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key.key).WithValues("gvr", key.gvr)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if requeue, err := c.process(ctx, key.key, key.gvr); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q (%s), err: %w", controllerName, key.key, key.gvr.String(), err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if requeue {
+		// only requeue if we didn't error, but we still want to requeue
+		c.queue.Add(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *cleanupController) process(ctx context.Context, key string, gvr schema.GroupVersionResource) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	clusterName, namespace, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false, nil
+	}
+
+	logger = logger.WithValues(logging.WorkspaceKey, clusterName, logging.NamespaceKey, namespace, logging.NameKey, name)
+	ctx = klog.NewContext(ctx, logger)
+
+	var errs []error
+	requeue, err := c.cleanupReconciler.reconcile(ctx, gvr, clusterName, namespace, name)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return requeue, utilerrors.NewAggregate(errs)
+}

--- a/pkg/syncer/upsync/upsync_cleanup_reconcile.go
+++ b/pkg/syncer/upsync/upsync_cleanup_reconcile.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+type cleanupReconciler struct {
+	getUpstreamClient func(clusterName logicalcluster.Name) (dynamic.Interface, error)
+
+	getDownstreamLister               func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	listDownstreamNamespacesByLocator func(jsonLocator string) ([]*unstructured.Unstructured, error)
+
+	syncTargetName        string
+	syncTargetClusterName logicalcluster.Name
+	syncTargetUID         types.UID
+}
+
+func (c *cleanupReconciler) reconcile(ctx context.Context, gvr schema.GroupVersionResource, upstreamClusterName logicalcluster.Name, upstreamNamespace, upstreamName string) (bool, error) {
+	downstreamResource, err := c.getDownstreamResource(ctx, gvr, upstreamClusterName, upstreamNamespace, upstreamName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	if downstreamResource != nil {
+		return false, nil
+	}
+
+	// Downstream resource not present => force delete resource upstream (also remove finalizers)
+	err = c.deleteOrphanUpstreamResource(ctx, gvr, upstreamClusterName, upstreamNamespace, upstreamName)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (c *cleanupReconciler) getDownstreamResource(ctx context.Context, gvr schema.GroupVersionResource, upstreamClusterName logicalcluster.Name, upstreamNamespace, upstreamName string) (*unstructured.Unstructured, error) {
+	logger := klog.FromContext(ctx)
+
+	downstreamNamespace := ""
+	if upstreamNamespace != "" {
+		// find downstream namespace through locator index
+		locator := shared.NewNamespaceLocator(upstreamClusterName, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
+		locatorValue, err := json.Marshal(locator)
+		if err != nil {
+			return nil, err
+		}
+		downstreamNamespaces, err := c.listDownstreamNamespacesByLocator(string(locatorValue))
+		if err != nil {
+			return nil, err
+		}
+		if len(downstreamNamespaces) == 1 {
+			namespace := downstreamNamespaces[0]
+			logger.WithValues(DownstreamName, namespace.GetName()).V(4).Info("Found downstream namespace for upstream namespace")
+			downstreamNamespace = namespace.GetName()
+		} else if len(downstreamNamespaces) > 1 {
+			// This should never happen unless there's some namespace collision.
+			var namespacesCollisions []string
+			for _, namespace := range downstreamNamespaces {
+				namespacesCollisions = append(namespacesCollisions, namespace.GetName())
+			}
+			return nil, fmt.Errorf("(namespace collision) found multiple downstream namespaces: %s for upstream namespace %s|%s", strings.Join(namespacesCollisions, ","), upstreamClusterName, upstreamNamespace)
+		} else {
+			logger.V(4).Info("No downstream namespaces found")
+			return nil, nil
+		}
+	}
+
+	// retrieve downstream object
+	downstreamLister, err := c.getDownstreamLister(gvr)
+	if err != nil {
+		return nil, err
+	}
+
+	var downstreamObject runtime.Object
+	if downstreamNamespace != "" {
+		downstreamObject, err = downstreamLister.ByNamespace(downstreamNamespace).Get(upstreamName)
+	} else {
+		downstreamObject, err = downstreamLister.Get(upstreamName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	downstreamResource, ok := downstreamObject.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("type mismatch of resource object: received %T", downstreamResource)
+	}
+
+	return downstreamResource, nil
+}
+
+func removeUpstreamResourceFinalizers(ctx context.Context, upstreamClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string) error {
+	existingResource, err := upstreamClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if len(existingResource.GetFinalizers()) > 0 {
+		existingResource.SetFinalizers(nil)
+		if _, err := upstreamClient.Resource(gvr).Namespace(namespace).Update(ctx, existingResource, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *cleanupReconciler) deleteOrphanUpstreamResource(ctx context.Context, gvr schema.GroupVersionResource, upstreamClusterName logicalcluster.Name, upstreamNamespace, upstreamName string) error {
+	// Downstream resource not present => force delete resource upstream (also remove finalizers)
+	upstreamClient, err := c.getUpstreamClient(upstreamClusterName)
+	if err != nil {
+		return err
+	}
+
+	if err := removeUpstreamResourceFinalizers(ctx, upstreamClient, gvr, upstreamNamespace, upstreamName); err != nil {
+		return err
+	}
+
+	err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Delete(ctx, upstreamName, metav1.DeleteOptions{})
+	return err
+}

--- a/pkg/syncer/upsync/upsync_controller.go
+++ b/pkg/syncer/upsync/upsync_controller.go
@@ -1,0 +1,446 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	syncerindexers "github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+const controllerName = "kcp-resource-upsyncer"
+
+var namespaceGVR schema.GroupVersionResource = corev1.SchemeGroupVersion.WithResource("namespaces")
+
+// NewUpSyncer returns a new controller which upsyncs, through the Upsyncer virtual workspace, downstream resources
+// which are part of the upsyncable resource types (fixed limited list for now), and provide
+// the following labels:
+//   - internal.workload.kcp.io/cluster: <sync target key>
+//   - state.workload.kcp.io/<sync target key>: Upsync
+//
+// and optionally, for cluster-wide resources, the `kcp.io/namespace-locator` annotation
+// filled with the information necessary identify the upstream workspace to upsync to.
+func NewUpSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name,
+	syncTargetName, syncTargetKey string,
+	getShardAccess synctarget.GetShardAccessFunc, downstreamClient dynamic.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	syncTargetUID types.UID) (*controller, error) {
+	c := &controller{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		reconciler: reconciler{
+			cleanupReconciler: cleanupReconciler{
+				getUpstreamClient: func(clusterName logicalcluster.Name) (dynamic.Interface, error) {
+					shardAccess, ok, err := getShardAccess(clusterName)
+					if err != nil {
+						return nil, err
+					}
+					if !ok {
+						return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+					}
+					return shardAccess.UpsyncerClient.Cluster(clusterName.Path()), nil
+				},
+				getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+					informers, notSynced := ddsifForDownstream.Informers()
+					informer, ok := informers[gvr]
+					if !ok {
+						if shared.ContainsGVR(notSynced, gvr) {
+							return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+						}
+						return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+					}
+					return informer.Lister(), nil
+				},
+				listDownstreamNamespacesByLocator: func(jsonLocator string) ([]*unstructured.Unstructured, error) {
+					nsInformer, err := ddsifForDownstream.ForResource(namespaceGVR)
+					if err != nil {
+						return nil, err
+					}
+					return indexers.ByIndex[*unstructured.Unstructured](nsInformer.Informer().GetIndexer(), syncerindexers.ByNamespaceLocatorIndexName, jsonLocator)
+				},
+
+				syncTargetName:        syncTargetName,
+				syncTargetClusterName: syncTargetClusterName,
+				syncTargetUID:         syncTargetUID,
+			},
+			getUpstreamUpsyncerLister: func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+				shardAccess, ok, err := getShardAccess(clusterName)
+				if err != nil {
+					return nil, err
+				}
+				if !ok {
+					return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+				}
+
+				informers, notSynced := shardAccess.UpsyncerDDSIF.Informers()
+				informer, ok := informers[gvr]
+				if !ok {
+					if shared.ContainsGVR(notSynced, gvr) {
+						return nil, fmt.Errorf("informer for gvr %v not synced in the upstream upsyncer informer factory -  should retry", gvr)
+					}
+					return nil, fmt.Errorf("gvr %v should be known in the upstream upsyncer informer factory", gvr)
+				}
+				return informer.Lister().ByCluster(clusterName), nil
+			},
+			getUpsyncedGVRs: func(clusterName logicalcluster.Name) ([]schema.GroupVersionResource, error) {
+				shardAccess, ok, err := getShardAccess(clusterName)
+				if err != nil {
+					return nil, err
+				}
+				if !ok {
+					return nil, fmt.Errorf("shard-related clients not found for cluster %q", clusterName)
+				}
+
+				informers, notSynced := shardAccess.UpsyncerDDSIF.Informers()
+				var result []schema.GroupVersionResource
+				for k := range informers {
+					result = append(result, k)
+				}
+				if len(notSynced) > 0 {
+					return result, fmt.Errorf("informers not synced in the upstream upsyncer informer factory for gvrs %v", notSynced)
+				}
+				return result, nil
+			},
+			syncTargetKey: syncTargetKey,
+		},
+	}
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	ddsifForDownstream.AddEventHandler(ddsif.GVREventHandlerFuncs{
+		AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if gvr == namespaceGVR {
+				return
+			}
+			new, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", obj))
+				return
+			}
+			if new.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] != string(workloadv1alpha1.ResourceStateUpsync) {
+				return
+			}
+			c.enqueueDownstream(gvr, new, logger, new.UnstructuredContent()["status"] != nil)
+		},
+		UpdateFunc: func(gvr schema.GroupVersionResource, oldObj, newObj interface{}) {
+			if gvr == namespaceGVR {
+				return
+			}
+			old, ok := oldObj.(*unstructured.Unstructured)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", oldObj))
+				return
+			}
+			new, ok := newObj.(*unstructured.Unstructured)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", newObj))
+				return
+			}
+			if new.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] != string(workloadv1alpha1.ResourceStateUpsync) {
+				return
+			}
+
+			oldStatus := old.UnstructuredContent()["status"]
+			newStatus := new.UnstructuredContent()["status"]
+			c.enqueueDownstream(gvr, new, logger, newStatus != nil && !equality.Semantic.DeepEqual(oldStatus, newStatus))
+		},
+		DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+			unstr, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				utilruntime.HandleError(fmt.Errorf("resource should be a *unstructured.Unstructured, but was %T", unstr))
+				return
+			}
+
+			if gvr == namespaceGVR {
+				c.enqueueDeletedDownstreamNamespace(unstr, logger)
+				return
+			}
+
+			if unstr.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetKey] != string(workloadv1alpha1.ResourceStateUpsync) {
+				return
+			}
+			c.enqueueDownstream(gvr, unstr, logger, false)
+		},
+	})
+	return c, nil
+}
+
+type controller struct {
+	queue workqueue.RateLimitingInterface
+
+	dirtyStatusKeys sync.Map
+
+	reconciler
+}
+
+// queueKey is a composite queue key that combines the gvr and the key of the upstream
+// resource that should be reconciled.
+type queueKey struct {
+	gvr schema.GroupVersionResource
+	// key is the cluster-aware cache key of the upstream resource
+	key string
+}
+
+func (c *controller) enqueueUpstream(gvr schema.GroupVersionResource, obj interface{}, logger logr.Logger, dirtyStatus bool) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	logging.WithQueueKey(logger, key).V(2).Info("queueing", "gvr", gvr.String())
+	queueKey := queueKey{
+		gvr: gvr,
+		key: key,
+	}
+
+	if dirtyStatus {
+		c.dirtyStatusKeys.Store(queueKey, true)
+	}
+	c.queue.Add(queueKey)
+}
+
+func (c *controller) enqueueDeletedDownstreamNamespace(deletedNamespace *unstructured.Unstructured, logger logr.Logger) {
+	upstreamLocator, locatorExists, err := shared.LocatorFromAnnotations(deletedNamespace.GetAnnotations())
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	if !locatorExists || upstreamLocator == nil {
+		logger.V(4).Info("the namespace locator doesn't exist on deleted downstream namespace.")
+		return
+	}
+
+	if upstreamLocator.SyncTarget.UID != c.syncTargetUID || upstreamLocator.SyncTarget.ClusterName != c.syncTargetClusterName.String() {
+		return
+	}
+
+	upsyncedGVRs, err := c.getUpsyncedGVRs(upstreamLocator.ClusterName)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	for _, gvr := range upsyncedGVRs {
+		upstreamLister, err := c.getUpstreamUpsyncerLister(upstreamLocator.ClusterName, gvr)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+
+		upstreamUpsyncedResources, err := upstreamLister.ByNamespace(upstreamLocator.Namespace).List(labels.Everything())
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+
+		for _, upstreamUpsyncedResource := range upstreamUpsyncedResources {
+			c.enqueueUpstream(gvr, upstreamUpsyncedResource, logger, false)
+		}
+	}
+}
+
+func (c *controller) enqueueDownstream(gvr schema.GroupVersionResource, downstreamObj *unstructured.Unstructured, logger logr.Logger, dirtyStatus bool) {
+	downstreamNamespace := downstreamObj.GetNamespace()
+	locatorHolder := downstreamObj
+	if downstreamNamespace != "" {
+		// get locator from namespace for namespaced objects
+		downstreamNamespaceLister, err := c.getDownstreamLister(namespaceGVR)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		nsObj, err := downstreamNamespaceLister.Get(downstreamNamespace)
+		if errors.IsNotFound(err) {
+			logger.V(4).Info("the downstream namespace doesn't exist anymore.")
+			return
+		}
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		if unstr, ok := nsObj.(*unstructured.Unstructured); !ok {
+			utilruntime.HandleError(fmt.Errorf("downstream ns expected to be *unstructured.Unstructured got %T", nsObj))
+			return
+		} else {
+			locatorHolder = unstr
+		}
+	}
+
+	upstreamLocator, locatorExists, err := shared.LocatorFromAnnotations(locatorHolder.GetAnnotations())
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+	if !locatorExists || upstreamLocator == nil {
+		logger.V(4).Info("the namespace locator doesn't exist on downstream namespace.")
+		return
+	}
+
+	if upstreamLocator.SyncTarget.UID != c.syncTargetUID || upstreamLocator.SyncTarget.ClusterName != c.syncTargetClusterName.String() {
+		return
+	}
+
+	c.enqueueUpstream(gvr, &metav1.ObjectMeta{
+		Name:      downstreamObj.GetName(),
+		Namespace: upstreamLocator.Namespace,
+		Annotations: map[string]string{
+			logicalcluster.AnnotationKey: upstreamLocator.ClusterName.String(),
+		},
+	}, logging.WithObject(logger, downstreamObj), dirtyStatus)
+}
+
+func (c *controller) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting upsync workers")
+	defer logger.Info("Stopping upsync workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(queueKey)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key.key).WithValues("gvr", key.gvr)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if requeue, err := c.process(ctx, key.key, key.gvr); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%q controller failed to sync %q (%s), err: %w", controllerName, key.key, key.gvr.String(), err))
+		c.queue.AddRateLimited(key)
+		return true
+	} else if requeue {
+		// only requeue if we didn't error, but we still want to requeue
+		c.queue.Add(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, key string, gvr schema.GroupVersionResource) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	clusterName, namespace, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return false, nil
+	}
+
+	dirtyStatus := false
+	if dirtyStatusObj, found := c.dirtyStatusKeys.LoadAndDelete(queueKey{
+		gvr: gvr,
+		key: key,
+	}); found {
+		dirtyStatus = dirtyStatusObj.(bool)
+	}
+
+	resetDirty := func(requeue bool, err error) (bool, error) {
+		if dirtyStatus && err != nil {
+			c.dirtyStatusKeys.Store(queueKey{
+				gvr: gvr,
+				key: key,
+			}, true)
+		}
+		return requeue, err
+	}
+
+	upstreamLister, err := c.getUpstreamUpsyncerLister(clusterName, gvr)
+	if err != nil {
+		return resetDirty(false, err)
+	}
+	getter := upstreamLister.Get
+	if namespace != "" {
+		getter = upstreamLister.ByNamespace(namespace).Get
+	}
+
+	upstreamObj, err := getter(name)
+	if err != nil && !errors.IsNotFound(err) {
+		return resetDirty(false, err)
+	}
+
+	var upstreamResource *unstructured.Unstructured
+	if upstreamObj != nil {
+		var ok bool
+		upstreamResource, ok = upstreamObj.(*unstructured.Unstructured)
+		if !ok {
+			logger.Error(nil, "got unexpected type", "type", fmt.Sprintf("%T", upstreamObj))
+			return false, nil // retrying won't help
+		}
+	}
+	logger = logger.WithValues(logging.WorkspaceKey, clusterName, logging.NamespaceKey, namespace, logging.NameKey, name)
+	ctx = klog.NewContext(ctx, logger)
+
+	var errs []error
+	requeue, err := c.reconcile(ctx, upstreamResource, gvr, clusterName, namespace, name, dirtyStatus)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	return resetDirty(requeue, utilerrors.NewAggregate(errs))
+}

--- a/pkg/syncer/upsync/upsync_process_test.go
+++ b/pkg/syncer/upsync/upsync_process_test.go
@@ -1,0 +1,984 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/synctarget"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+}
+
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+	upsyncer bool
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "persistentvolumes",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "persistentvolume",
+				Kind:     "PersistentVolume",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "pods",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "pod",
+				Kind:     "Pod",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
+func TestUpsyncerprocess(t *testing.T) {
+	type testCase struct {
+		downstreamNamespace   *corev1.Namespace
+		upstreamNamespaceName string
+		gvr                   schema.GroupVersionResource
+		downstreamResource    runtime.Object
+		upstreamResource      runtime.Object
+		doOnDownstream        func(tc testCase, client dynamic.Interface)
+
+		resourceToProcessName string
+
+		upstreamLogicalCluster    logicalcluster.Name
+		syncTargetName            string
+		syncTargetClusterName     logicalcluster.Name
+		syncTargetUID             types.UID
+		expectError               bool
+		expectRequeue             bool
+		expectActionsOnDownstream []clienttesting.Action
+		expectActionsOnUpstream   []kcptesting.Action
+		includeStatus             bool
+	}
+	tests := map[string]testCase{
+		"Upsyncer upsyncs namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Unstructured(t).WithoutFields("status").Unstructured,
+			upstreamResource:          nil,
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "1",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithoutFields("status").Unstructured),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer upsyncs namespaced resources with status": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured,
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+				kcptesting.NewUpdateSubresourceAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "status", "test", pod("test-pod").
+					WithNamespace("test").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "1",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+			},
+			includeStatus: true,
+		},
+		"Upsyncer upsyncs cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "",
+			downstreamNamespace:    nil,
+			gvr:                    corev1.SchemeGroupVersion.WithResource("persistentvolumes"),
+			downstreamResource: pv("test-pv").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}).
+				Unstructured(t).WithoutFields("status").Unstructured,
+			upstreamResource:          nil,
+			resourceToProcessName:     "test-pv",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewCreateAction(corev1.SchemeGroupVersion.WithResource("persistentvolumes"), logicalcluster.NewPath("root:org:ws"), "", pv("test-pv").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "1",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithoutFields("status").Unstructured),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer updates namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("2").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Unstructured(t).WithoutFields("status").Unstructured,
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"workload.kcp.io/rv": "1",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewUpdateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "2",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					WithResourceVersion("1").
+					Unstructured(t).WithoutFields("status").Unstructured),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer updates namespaced resources, even if they already have a deletion timestamp, but requeue": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("2").
+				WithDeletionTimestamp().
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Unstructured(t).WithoutFields("status").Unstructured,
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"workload.kcp.io/rv": "1",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectRequeue:             true,
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "2",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithoutFields("status").Unstructured),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer udpates namespaced resources with status": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("11").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured,
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"workload.kcp.io/rv": "10",
+				}).
+				Unstructured(t).Unstructured,
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{"workload.kcp.io/rv": "10"}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+				kcptesting.NewUpdateSubresourceAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "status", "test", pod("test-pod").
+					WithNamespace("test").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "10",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithNamespace("test").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "11",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithField("status", map[string]interface{}{"phase": "Running"}).Unstructured),
+			},
+			includeStatus: true,
+		},
+		"Upsyncer updates cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "",
+			downstreamNamespace:    nil,
+			gvr:                    corev1.SchemeGroupVersion.WithResource("persistentvolumes"),
+			downstreamResource: pv("test-pv").
+				WithResourceVersion("2").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}).
+				Unstructured(t).WithoutFields("status").Unstructured,
+			upstreamResource: pv("test-pv").
+				WithClusterName("root:org:ws").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"workload.kcp.io/rv": "1",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pv",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("persistentvolumes"), logicalcluster.NewPath("root:org:ws"), "", "test-pv"),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("persistentvolumes"), logicalcluster.NewPath("root:org:ws"), "", pv("test-pv").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					WithAnnotations(map[string]string{
+						"workload.kcp.io/rv": "2",
+					}).
+					WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+					Unstructured(t).WithoutFields("status").Unstructured),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer deletes orphan upstream namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer should delete orphan upstream namespaced resource, but it doesn't exist": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr:                       corev1.SchemeGroupVersion.WithResource("pods"),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer deletes orphan upstream namespaced resources, even if the downstream namespace has also been deleted": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace:    nil,
+			gvr:                    corev1.SchemeGroupVersion.WithResource("pods"),
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer deletes orphan upstream namespaced resources when downstream namespace is deleted": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			downstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Object(),
+			doOnDownstream: func(tc testCase, client dynamic.Interface) {
+				err := client.Resource(namespaceGVR).Delete(context.Background(), "kcp-33jbiactwhg0", metav1.DeleteOptions{})
+				require.NoError(t, err)
+			},
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer deletes orphan upstream cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "",
+			downstreamNamespace:    nil,
+			gvr:                    corev1.SchemeGroupVersion.WithResource("persistentvolumes"),
+			downstreamResource:     nil,
+			upstreamResource: pv("test-pv").
+				WithClusterName("root:org:ws").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pv",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("persistentvolumes"), logicalcluster.NewPath("root:org:ws"), "", "test-pv"),
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("persistentvolumes"), logicalcluster.NewPath("root:org:ws"), "", "test-pv"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer deletes upstream resources if downstream resources have deletiontimestamp set": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			downstreamResource: pod("test-pod").
+				WithNamespace("kcp-33jbiactwhg0").
+				WithDeletionTimestamp().
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithResourceVersion("1").
+				Object(),
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"workload.kcp.io/rv": "1",
+				}).
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+		"Upsyncer handles deletion of upstream resources when they have finalizers set": {
+			upstreamLogicalCluster: "root:org:ws",
+			upstreamNamespaceName:  "test",
+			downstreamNamespace: namespace("kcp-33jbiactwhg0").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithAnnotations(map[string]string{
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
+				}).
+				Object(),
+			gvr: corev1.SchemeGroupVersion.WithResource("pods"),
+			upstreamResource: pod("test-pod").
+				WithClusterName("root:org:ws").
+				WithNamespace("test").
+				WithResourceVersion("1").
+				WithLabels(map[string]string{
+					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}).
+				WithFinalizers("workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g").
+				Object(),
+			resourceToProcessName:     "test-pod",
+			syncTargetName:            "us-west1",
+			expectActionsOnDownstream: []clienttesting.Action{},
+			expectActionsOnUpstream: []kcptesting.Action{
+				kcptesting.NewGetAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+				kcptesting.NewUpdateAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", pod("test-pod").
+					WithClusterName("root:org:ws").
+					WithNamespace("test").
+					WithResourceVersion("1").
+					WithLabels(map[string]string{
+						"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+						"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}).
+					Unstructured(t).Unstructured),
+				kcptesting.NewDeleteAction(corev1.SchemeGroupVersion.WithResource("pods"), logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
+			},
+			includeStatus: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := klog.FromContext(ctx)
+
+			kcpLogicalCluster := tc.upstreamLogicalCluster
+			syncTargetUID := tc.syncTargetUID
+			if tc.syncTargetUID == "" {
+				syncTargetUID = types.UID("syncTargetUID")
+			}
+
+			if tc.syncTargetClusterName.Empty() {
+				tc.syncTargetClusterName = "root:org:ws"
+			}
+
+			var allFromResources []runtime.Object
+			if tc.downstreamNamespace != nil {
+				allFromResources = append(allFromResources, tc.downstreamNamespace)
+			}
+			if tc.downstreamResource != nil {
+				allFromResources = append(allFromResources, tc.downstreamResource)
+			}
+
+			fromClient := dynamicfake.NewSimpleDynamicClient(scheme, allFromResources...)
+
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetClusterName, tc.syncTargetName)
+
+			var toResources []runtime.Object
+			if tc.upstreamResource != nil {
+				toResources = append(toResources, tc.upstreamResource)
+			}
+			toClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, toResources...)
+
+			ddsifForUpstreamUpsyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(toClusterClient, nil, nil, &mockedGVRSource{true}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(fromClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			setupServersideApplyPatchReactor(toClusterClient)
+			fromClientResourceWatcherStarted := setupWatchReactor(t, tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupClusterWatchReactor(t, tc.gvr.Resource, toClusterClient)
+
+			// upstream => to (kcp)
+			// downstream => from (physical cluster)
+			// to === kcp
+			// from === physical
+			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, func(clusterName logicalcluster.Name) (synctarget.ShardAccess, bool, error) {
+				return synctarget.ShardAccess{
+					UpsyncerClient: toClusterClient,
+					UpsyncerDDSIF:  ddsifForUpstreamUpsyncer,
+				}, true, nil
+			}, fromClient, ddsifForDownstream, syncTargetUID)
+			require.NoError(t, err)
+
+			ddsifForUpstreamUpsyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamUpsyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
+
+			<-fromClientResourceWatcherStarted
+			<-toClientResourceWatcherStarted
+
+			// The only GVRs we care about are the 3 listed below
+			t.Logf("waiting for upstream and downstream dynamic informer factories to be synced")
+			gvrs := sets.New[string](
+				corev1.SchemeGroupVersion.WithResource("namespaces").String(),
+				corev1.SchemeGroupVersion.WithResource("pods").String(),
+				corev1.SchemeGroupVersion.WithResource("persistentvolumes").String(),
+			)
+			require.Eventually(t, func() bool {
+				syncedUpstream, _ := ddsifForUpstreamUpsyncer.Informers()
+				foundUpstream := sets.New[string]()
+				for gvr := range syncedUpstream {
+					foundUpstream.Insert(gvr.String())
+				}
+
+				syncedDownstream, _ := ddsifForDownstream.Informers()
+				foundDownstream := sets.New[string]()
+				for gvr := range syncedDownstream {
+					foundDownstream.Insert(gvr.String())
+				}
+				return foundUpstream.IsSuperset(gvrs) && foundDownstream.IsSuperset(gvrs)
+			}, wait.ForeverTestTimeout, 100*time.Millisecond)
+			t.Logf("upstream and downstream dynamic informer factories are synced")
+
+			if tc.doOnDownstream != nil {
+				tc.doOnDownstream(tc, fromClient)
+			}
+
+			fromClient.ClearActions()
+			toClusterClient.ClearActions()
+
+			obj := &metav1.ObjectMeta{
+				Name:      tc.resourceToProcessName,
+				Namespace: tc.upstreamNamespaceName,
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: kcpLogicalCluster.String(),
+				},
+			}
+
+			key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+			require.NoError(t, err)
+
+			if tc.includeStatus {
+				controller.dirtyStatusKeys.Store(queueKey{
+					key: key,
+					gvr: tc.gvr,
+				}, true)
+			}
+
+			requeue, err := controller.process(context.Background(), key, tc.gvr)
+			assert.Equal(t, tc.expectRequeue, requeue)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnDownstream, fromClient.Actions()))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnUpstream, toClusterClient.Actions()))
+		})
+	}
+}
+
+func setupWatchReactor(t *testing.T, resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+	t.Helper()
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		t.Logf("%s: watcher started", t.Name())
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	return watcherStarted
+}
+
+func setupClusterWatchReactor(t *testing.T, resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	t.Helper()
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action kcptesting.Action) (bool, watch.Interface, error) {
+		cluster := action.GetCluster()
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		var watcher watch.Interface
+		var err error
+		switch cluster {
+		case logicalcluster.Wildcard:
+			watcher, err = client.Tracker().Watch(gvr, ns)
+		default:
+			watcher, err = client.Tracker().Cluster(cluster).Watch(gvr, ns)
+		}
+		t.Logf("%s: cluster watcher started", t.Name())
+		close(watcherStarted)
+		return true, watcher, err
+	})
+	return watcherStarted
+}
+
+func setupServersideApplyPatchReactor(toClient *kcpfakedynamic.FakeDynamicClusterClientset) {
+	toClient.PrependReactor("patch", "*", func(action kcptesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kcptesting.PatchAction)
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		return true, nil, err
+	})
+}
+
+type resourceBuilder[Type metav1.Object] struct {
+	obj Type
+}
+
+func (r *resourceBuilder[Type]) Object() Type {
+	return r.obj
+}
+
+type unstructuredType struct {
+	*unstructured.Unstructured
+	t *testing.T
+}
+
+func (u *unstructuredType) WithoutFields(fieldsToPrune ...string) *unstructuredType {
+	for _, field := range fieldsToPrune {
+		unstructured.RemoveNestedField(u.Object, strings.Split(field, ".")...)
+	}
+
+	return u
+}
+
+func (u *unstructuredType) WithField(key string, value interface{}) *unstructuredType {
+	err := unstructured.SetNestedField(u.Object, value, strings.Split(key, ".")...)
+	require.NoError(u.t, err)
+	return u
+}
+
+func (r *resourceBuilder[Type]) Unstructured(t *testing.T) *unstructuredType {
+	var unstr unstructured.Unstructured
+	err := scheme.Convert(r.obj, &unstr, nil)
+	require.NoError(t, err)
+	result := unstructuredType{&unstr, t}
+	return &result
+}
+
+func (r *resourceBuilder[Type]) WithNamespace(namespace string) *resourceBuilder[Type] {
+	r.obj.SetNamespace(namespace)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithResourceVersion(resourceVersion string) *resourceBuilder[Type] {
+	r.obj.SetResourceVersion(resourceVersion)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithDeletionTimestamp() *resourceBuilder[Type] {
+	now := metav1.Now()
+	r.obj.SetDeletionTimestamp(&now)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithClusterName(clusterName string) *resourceBuilder[Type] {
+	annotations := r.obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[logicalcluster.AnnotationKey] = clusterName
+
+	r.obj.SetAnnotations(annotations)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithAnnotations(additionalAnnotations map[string]string) *resourceBuilder[Type] {
+	annotations := r.obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for k, v := range additionalAnnotations {
+		annotations[k] = v
+	}
+
+	r.obj.SetAnnotations(annotations)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithLabels(additionalLabels map[string]string) *resourceBuilder[Type] {
+	labels := r.obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	for k, v := range additionalLabels {
+		labels[k] = v
+	}
+
+	r.obj.SetLabels(labels)
+	return r
+}
+
+func (r *resourceBuilder[Type]) WithFinalizers(finalizers ...string) *resourceBuilder[Type] {
+	r.obj.SetFinalizers(finalizers)
+	return r
+}
+
+func newResourceBuilder[Type metav1.Object](obj Type, name string) *resourceBuilder[Type] {
+	obj.SetName(name)
+	return &resourceBuilder[Type]{obj}
+}
+
+func namespace(name string) *resourceBuilder[*corev1.Namespace] {
+	return newResourceBuilder(&corev1.Namespace{}, name)
+}
+
+func pv(name string) *resourceBuilder[*corev1.PersistentVolume] {
+	return newResourceBuilder(&corev1.PersistentVolume{}, name)
+}
+
+func pod(name string) *resourceBuilder[*corev1.Pod] {
+	return newResourceBuilder(&corev1.Pod{}, name)
+}

--- a/pkg/syncer/upsync/upsync_reconcile.go
+++ b/pkg/syncer/upsync/upsync_reconcile.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+)
+
+const (
+	// ResourceVersionAnnotation is an annotation set on a resource upsynced upstream
+	// that contains the resourceVersion of the corresponding downstream resource
+	// when it was last upsynced.
+	// It is used to check easily, without having to compare the resource contents,
+	// whether an upsynced upstream resource is up-to-date with the downstream resource.
+	ResourceVersionAnnotation = "workload.kcp.io/rv"
+)
+
+type reconciler struct {
+	cleanupReconciler
+
+	getUpstreamUpsyncerLister func(clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	getUpsyncedGVRs           func(clusterName logicalcluster.Name) ([]schema.GroupVersionResource, error)
+
+	syncTargetKey string
+}
+
+func (c *reconciler) reconcile(ctx context.Context, upstreamObject *unstructured.Unstructured, gvr schema.GroupVersionResource, upstreamClusterName logicalcluster.Name, upstreamNamespace, upstreamName string, dirtyStatus bool) (bool, error) {
+	logger := klog.FromContext(ctx)
+
+	downstreamResource, err := c.cleanupReconciler.getDownstreamResource(ctx, gvr, upstreamClusterName, upstreamNamespace, upstreamName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, err
+	}
+	if downstreamResource == nil {
+		// Downstream resource not present => force delete resource upstream (also remove finalizers)
+		err = c.deleteOrphanUpstreamResource(ctx, gvr, upstreamClusterName, upstreamNamespace, upstreamName)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	upstreamClient, err := c.getUpstreamClient(upstreamClusterName)
+	if err != nil {
+		return false, err
+	}
+
+	logger = logger.WithValues(DownstreamNamespace, downstreamResource.GetNamespace())
+	ctx = klog.NewContext(ctx, logger)
+
+	downstreamRV := downstreamResource.GetResourceVersion()
+	markedForDeletionDownstream := downstreamResource.GetDeletionTimestamp() != nil
+
+	// (potentially) create object upstream
+	if upstreamObject == nil {
+		if markedForDeletionDownstream {
+			return false, nil
+		}
+		logger.V(1).Info("Creating resource upstream")
+		preparedResource := c.prepareResourceForUpstream(ctx, gvr, upstreamNamespace, upstreamClusterName, downstreamResource)
+
+		if !dirtyStatus {
+			// if no status needs to be upsynced upstream, then we can set the resource version annotation at the same time as we create the
+			// resource
+			preparedResource.SetAnnotations(addResourceVersionAnnotation(downstreamRV, preparedResource.GetAnnotations()))
+			// Create the resource
+			_, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Create(ctx, preparedResource, metav1.CreateOptions{})
+			return false, err
+		}
+
+		// Status also needs to be upsynced so let's do it in 3 steps:
+		// - create the resource
+		createdResource, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Create(ctx, preparedResource, metav1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
+		// - update the status as a distinct action,
+		preparedResource.SetResourceVersion(createdResource.GetResourceVersion())
+		updatedResource, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).UpdateStatus(ctx, preparedResource, metav1.UpdateOptions{})
+		if err != nil {
+			return false, err
+		}
+		// - finally update the main content again to set the resource version annotation to the value of the downstream resource version
+		preparedResource.SetAnnotations(addResourceVersionAnnotation(downstreamRV, preparedResource.GetAnnotations()))
+		preparedResource.SetResourceVersion(updatedResource.GetResourceVersion())
+		_, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Update(ctx, preparedResource, metav1.UpdateOptions{})
+		return false, err
+	}
+
+	// update upstream when annotation RV differs
+	resourceVersionUpstream := upstreamObject.GetAnnotations()[ResourceVersionAnnotation]
+	if downstreamRV != resourceVersionUpstream {
+		logger.V(1).Info("Updating upstream resource")
+		preparedResource := c.prepareResourceForUpstream(ctx, gvr, upstreamNamespace, upstreamClusterName, downstreamResource)
+		if err != nil {
+			return false, err
+		}
+
+		// quick path: status unchanged, only update main resource
+		if !dirtyStatus {
+			preparedResource.SetAnnotations(addResourceVersionAnnotation(downstreamRV, preparedResource.GetAnnotations()))
+			existingResource, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, preparedResource.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			preparedResource.SetResourceVersion(existingResource.GetResourceVersion())
+			_, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Update(ctx, preparedResource, metav1.UpdateOptions{})
+			// If the downstream resource is marked for deletion, let's requeue it to manage the deletion timestamp
+			return markedForDeletionDownstream, err
+		}
+
+		// slow path: status changed => we need 3 steps
+		// 1. update main resource
+
+		preparedResource.SetAnnotations(addResourceVersionAnnotation(resourceVersionUpstream, preparedResource.GetAnnotations()))
+		existingResource, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, preparedResource.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		preparedResource.SetResourceVersion(existingResource.GetResourceVersion())
+		updatedResource, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Update(ctx, preparedResource, metav1.UpdateOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// 2. update the status as a distinct action,
+		preparedResource.SetResourceVersion(updatedResource.GetResourceVersion())
+		updatedResource, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).UpdateStatus(ctx, preparedResource, metav1.UpdateOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// 3. finally update the main resource again to set the resource version annotation to the value of the downstream resource version.
+		preparedResource.SetAnnotations(addResourceVersionAnnotation(downstreamRV, preparedResource.GetAnnotations()))
+		preparedResource.SetResourceVersion(updatedResource.GetResourceVersion())
+		_, err = upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Update(ctx, preparedResource, metav1.UpdateOptions{})
+		// If the downstream resource is marked for deletion, let's requeue it to manage the deletion timestamp
+		return markedForDeletionDownstream, err
+	}
+
+	if downstreamResource.GetDeletionTimestamp() != nil {
+		if err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Delete(ctx, upstreamName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+func (c *reconciler) prepareResourceForUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNS string, upstreamLogicalCluster logicalcluster.Name, downstreamObj *unstructured.Unstructured) *unstructured.Unstructured {
+	// Make a deepcopy
+	resourceToUpsync := downstreamObj.DeepCopy()
+	annotations := resourceToUpsync.GetAnnotations()
+	if annotations != nil {
+		delete(annotations, shared.NamespaceLocatorAnnotation)
+		resourceToUpsync.SetAnnotations(annotations)
+	}
+	labels := resourceToUpsync.GetLabels()
+	if labels != nil {
+		delete(labels, workloadv1alpha1.InternalDownstreamClusterLabel)
+		resourceToUpsync.SetLabels(labels)
+	}
+	resourceToUpsync.SetNamespace(upstreamNS)
+	resourceToUpsync.SetUID("")
+	resourceToUpsync.SetResourceVersion("")
+	resourceToUpsync.SetManagedFields(nil)
+	resourceToUpsync.SetDeletionTimestamp(nil)
+	resourceToUpsync.SetDeletionGracePeriodSeconds(nil)
+	resourceToUpsync.SetOwnerReferences(nil)
+	resourceToUpsync.SetFinalizers([]string{shared.SyncerFinalizerNamePrefix + c.syncTargetKey})
+
+	return resourceToUpsync
+}
+
+func addResourceVersionAnnotation(resourceVersion string, annotations map[string]string) map[string]string {
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	annotations[ResourceVersionAnnotation] = resourceVersion
+	return annotations
+}

--- a/pkg/tunneler/dialer.go
+++ b/pkg/tunneler/dialer.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+// Based on https://github.com/golang/build/blob/master/tunneler/v2/tunneler.go
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// The Dialer can create new connections back to the origin.
+// A Dialer can have multiple clients.
+type Dialer struct {
+	conn         net.Conn      // control plane connection
+	incomingConn chan net.Conn // data plane connections
+	connReady    chan bool
+	pickupFailed chan error
+	donec        chan struct{}
+	closeOnce    sync.Once
+}
+
+// NewDialer returns the side of the connection which will initiate
+// new connections over the already established reverse connections.
+func NewDialer(conn net.Conn) *Dialer {
+	d := &Dialer{
+		conn:         conn,
+		donec:        make(chan struct{}),
+		connReady:    make(chan bool),
+		pickupFailed: make(chan error),
+		incomingConn: make(chan net.Conn),
+	}
+	go d.serve()
+	return d
+}
+
+// serve blocks and runs the control message loop, keeping the peer
+// alive and notifying the peer when new connections are available.
+func (d *Dialer) serve() {
+	defer d.Close()
+	go func() {
+		defer d.Close()
+		br := bufio.NewReader(d.conn)
+		for {
+			line, err := br.ReadSlice('\n')
+			if err != nil {
+				return
+			}
+			select {
+			case <-d.donec:
+				return
+			default:
+			}
+			var msg controlMsg
+			if err := json.Unmarshal(line, &msg); err != nil {
+				log.Printf("tunneler.Dialer read invalid JSON: %q: %v", line, err)
+				return
+			}
+			switch msg.Command {
+			case "pickup-failed":
+				err := fmt.Errorf("tunneler listener failed to pick up connection: %v", msg.Err)
+				select {
+				case d.pickupFailed <- err:
+				case <-d.donec:
+					return
+				}
+			}
+		}
+	}()
+	for {
+		if err := d.sendMessage(controlMsg{Command: "keep-alive"}); err != nil {
+			return
+		}
+
+		t := time.NewTimer(30 * time.Second)
+		select {
+		case <-t.C:
+			continue
+		case <-d.connReady:
+			if err := d.sendMessage(controlMsg{
+				Command:  "conn-ready",
+				ConnPath: "",
+			}); err != nil {
+				return
+			}
+		case <-d.donec:
+			return
+		}
+	}
+}
+
+func (d *Dialer) sendMessage(m controlMsg) error {
+	j, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	err = d.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	if err != nil {
+		return err
+	}
+	j = append(j, '\n')
+	_, err = d.conn.Write(j)
+	if err != nil {
+		return err
+	}
+	return d.conn.SetWriteDeadline(time.Time{})
+}
+
+// Done returns a channel which is closed when d is closed (either by
+// this process on purpose, by a local error, or close or error from
+// the peer).
+func (d *Dialer) Done() <-chan struct{} { return d.donec }
+
+// Close closes the Dialer.
+func (d *Dialer) Close() error {
+	d.closeOnce.Do(d.close)
+	return nil
+}
+
+func (d *Dialer) close() {
+	d.conn.Close()
+	close(d.donec)
+}
+
+// Dial creates a new connection back to the Listener.
+func (d *Dialer) Dial(ctx context.Context, network string, address string) (net.Conn, error) {
+	now := time.Now()
+	defer klog.FromContext(ctx).V(5).WithValues("address", address, "duration", time.Since(now)).Info("dialed")
+	// First, tell serve that we want a connection:
+	select {
+	case d.connReady <- true:
+	case <-d.donec:
+		return nil, errors.New("tunneler.Dialer closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Then pick it up:
+	select {
+	case c := <-d.incomingConn:
+		return c, nil
+	case err := <-d.pickupFailed:
+		return nil, err
+	case <-d.donec:
+		return nil, errors.New("tunneler.Dialer closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/pkg/tunneler/integration_test.go
+++ b/pkg/tunneler/integration_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// requestInfoHandler is a helping function to populate the requestInfo of a request as expected
+// by the WithSyncerTunnelHandler.
+func requestInfoHandler(handler http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if _, ok := genericapirequest.RequestInfoFrom(ctx); ok {
+			handler.ServeHTTP(w, r)
+			return
+		}
+		r = r.WithContext(genericapirequest.WithRequestInfo(ctx,
+			&genericapirequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "workload.kcp.io",
+				APIVersion:        "v1alpha1",
+				Resource:          "synctargets",
+				Subresource:       "tunnel",
+				Name:              "d001",
+			},
+		))
+		r = r.WithContext(genericapirequest.WithCluster(r.Context(), genericapirequest.Cluster{Name: "ws"}))
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func setup(t *testing.T) (string, *tunneler, func()) {
+	t.Helper()
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello world")
+	}))
+	backend.EnableHTTP2 = true
+	backend.StartTLS()
+
+	// public server
+	mux := http.NewServeMux()
+	tunneler := NewTunneler()
+	apiHandler := tunneler.WithSyncerTunnelHandler(mux)
+	apiHandler = requestInfoHandler(apiHandler)
+	publicServer := httptest.NewUnstartedServer(apiHandler)
+	publicServer.EnableHTTP2 = true
+	publicServer.StartTLS()
+
+	// private server
+	dstURL, err := SyncerTunnelURL(publicServer.URL, "ws", "d001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := NewListener(publicServer.Client(), dstURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reverse proxy queries to an internal host
+	url, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.Transport = backend.Client().Transport
+	server := &http.Server{Handler: proxy}
+	//nolint:errcheck
+	go server.Serve(l)
+
+	// client
+	// wait for the reverse connection to be established
+	time.Sleep(1 * time.Second)
+	stop := func() {
+		l.Close()
+		server.Close()
+		publicServer.Close()
+		backend.Close()
+	}
+	return dstURL, tunneler, stop
+}
+
+func Test_integration(t *testing.T) {
+	uri, tunneler, stop := setup(t)
+	rw := httptest.NewRecorder()
+	b := &bytes.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, uri, b) //nolint:noctx
+	require.NoError(t, err)
+	tunneler.Proxy("ws", "d001", rw, req)
+	defer stop()
+
+	response := rw.Result()
+	body, err := io.ReadAll(response.Body)
+	defer response.Body.Close()
+	if err != nil {
+		t.Fatalf("Reading body failed: %s", err)
+	}
+
+	// Log the request body
+	bodyString := string(body)
+	if bodyString != "Hello world" {
+		t.Errorf("Expected %s received %s", "Hello world", bodyString)
+	}
+}
+
+func Test_integration_multiple_connections(t *testing.T) {
+	uri, tunneler, stop := setup(t)
+	defer stop()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rw := httptest.NewRecorder()
+			b := &bytes.Buffer{}
+			req, err := http.NewRequest(http.MethodGet, uri, b) //nolint:noctx
+			require.NoError(t, err)
+			tunneler.Proxy("ws", "d001", rw, req)
+
+			response := rw.Result()
+			body, err := io.ReadAll(response.Body)
+			defer response.Body.Close()
+			if err != nil {
+				t.Errorf("Reading body failed: %s", err)
+			}
+
+			// Log the request body
+			bodyString := string(body)
+			if bodyString != "Hello world" {
+				t.Errorf("Expected %s received %s", "Hello world", bodyString)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func Test_integration_listener_reconnect(t *testing.T) {
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello world")
+	}))
+	backend.EnableHTTP2 = true
+	backend.StartTLS()
+	defer backend.Close()
+
+	// public server
+	mux := http.NewServeMux()
+	tunneler := NewTunneler()
+	apiHandler := tunneler.WithSyncerTunnelHandler(mux)
+	apiHandler = requestInfoHandler(apiHandler)
+	publicServer := httptest.NewUnstartedServer(apiHandler)
+	publicServer.EnableHTTP2 = true
+	publicServer.StartTLS()
+	defer publicServer.Close()
+
+	// private server
+	dstURL, err := SyncerTunnelURL(publicServer.URL, "ws", "d001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := NewListener(publicServer.Client(), dstURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// reverse proxy queries to an internal host
+	url, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.Transport = backend.Client().Transport
+	server := &http.Server{Handler: proxy}
+	//nolint:errcheck
+	go server.Serve(l)
+	defer server.Close()
+
+	// client
+	// wait for the reverse connection to be established
+	time.Sleep(1 * time.Second)
+
+	rw := httptest.NewRecorder()
+	b := &bytes.Buffer{}
+	req, err := http.NewRequest(http.MethodGet, dstURL, b) //nolint:noctx
+	require.NoError(t, err)
+	tunneler.Proxy("ws", "d001", rw, req)
+
+	response := rw.Result()
+	body, err := io.ReadAll(response.Body)
+	defer response.Body.Close()
+	if err != nil {
+		t.Fatalf("Reading body failed: %s", err)
+	}
+	// Log the request body
+	bodyString := string(body)
+	if bodyString != "Hello world" {
+		t.Errorf("Expected %s received %s", "Hello world", bodyString)
+	}
+
+	// reconnect
+	server.Close()
+	l.Close()
+	<-l.donec
+	l = nil
+
+	l2, err := NewListener(publicServer.Client(), dstURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l2.Close()
+	server2 := &http.Server{Handler: proxy}
+	//nolint:errcheck
+	go server2.Serve(l2)
+	defer server2.Close()
+
+	rw2 := httptest.NewRecorder()
+	b2 := &bytes.Buffer{}
+	req2, err := http.NewRequest(http.MethodGet, dstURL, b2) //nolint:noctx
+	require.NoError(t, err)
+	tunneler.Proxy("ws", "d001", rw2, req2)
+
+	response = rw2.Result()
+	body, err = io.ReadAll(response.Body)
+	defer response.Body.Close()
+	if err != nil {
+		t.Fatalf("Reading body failed: %s", err)
+	}
+
+	// Log the request body
+	bodyString = string(body)
+	if bodyString != "Hello world" {
+		t.Errorf("Expected %s received %s", "Hello world", bodyString)
+	}
+}

--- a/pkg/tunneler/listener.go
+++ b/pkg/tunneler/listener.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+// Based on https://github.com/golang/build/blob/master/tunneler/v2/tunneler.go
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/aojea/rwconn"
+	"golang.org/x/net/http2"
+
+	"k8s.io/klog/v2"
+)
+
+var _ net.Listener = (*Listener)(nil)
+
+// Listener is a net.Listener, returning new connections which arrive
+// from a corresponding Dialer.
+type Listener struct {
+	url    string
+	client *http.Client
+
+	sc     net.Conn // control plane connection
+	connc  chan net.Conn
+	donec  chan struct{}
+	writec chan<- []byte
+
+	mu      sync.Mutex // guards below, closing connc, and writing to rw
+	readErr error
+	closed  bool
+}
+
+// NewListener returns a new Listener, it dials to the Dialer
+// creating "reverse connection" that are accepted by this Listener.
+// - client: http client, required for TLS
+// - url: a URL to the base of the reverse handler on the Dialer.
+func NewListener(client *http.Client, url string) (*Listener, error) {
+	err := configureHTTP2Transport(client)
+	if err != nil {
+		return nil, err
+	}
+
+	ln := &Listener{
+		url:    url,
+		client: client,
+		connc:  make(chan net.Conn, 4), // arbitrary
+		donec:  make(chan struct{}),
+	}
+
+	// create control plane connection
+	// poor man backoff retry
+	sleep := 1 * time.Second
+	var c net.Conn
+	for attempts := 5; attempts > 0; attempts-- {
+		c, err = ln.dial()
+		if err != nil {
+			klog.Background().V(5).WithValues("err", err).Info("can not create control connection")
+			// Add some randomness to prevent creating a Thundering Herd
+			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			sleep = 2*sleep + jitter/2
+			time.Sleep(sleep)
+		} else {
+			ln.sc = c
+			break
+		}
+	}
+	if c == nil || err != nil {
+		return nil, err
+	}
+
+	go ln.run()
+	return ln, nil
+}
+
+// run establish reverse connections against the server.
+func (ln *Listener) run() {
+	defer ln.Close()
+
+	// Write loop
+	writec := make(chan []byte, 8)
+	ln.writec = writec
+	go func() {
+		for {
+			select {
+			case <-ln.donec:
+				return
+			case msg := <-writec:
+				if _, err := ln.sc.Write(msg); err != nil {
+					log.Printf("tunneler.Listener: error writing message to server: %v", err)
+					ln.Close()
+					return
+				}
+			}
+		}
+	}()
+
+	// Read loop
+	br := bufio.NewReader(ln.sc)
+	for {
+		line, err := br.ReadSlice('\n')
+		if err != nil {
+			return
+		}
+		var msg controlMsg
+		if err := json.Unmarshal(line, &msg); err != nil {
+			log.Printf("tunneler.Listener read invalid JSON: %q: %v", line, err)
+			return
+		}
+		switch msg.Command {
+		case "keep-alive":
+			// Occasional no-op message from server to keep
+			// us alive through NAT timeouts.
+		case "conn-ready":
+			go ln.grabConn()
+		default:
+			// Ignore unknown messages
+		}
+	}
+}
+
+func (ln *Listener) sendMessage(m controlMsg) {
+	j, _ := json.Marshal(m) //nolint:errchkjson
+	j = append(j, '\n')
+	ln.writec <- j
+}
+
+func (ln *Listener) dial() (net.Conn, error) {
+	connect := ln.url + "/" + tunnelSubresourcePath
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest(http.MethodGet, connect, pr) //nolint:noctx
+	if err != nil {
+		klog.Background().V(5).WithValues("err", err).Info("can not create request")
+		return nil, err
+	}
+
+	logger := klog.Background().WithValues("address", connect)
+	logger.V(5).Info("listener creating connection to address")
+	res, err := ln.client.Do(req) //nolint:bodyclose // Seems we're returning the connection with res.Body, caller closes it?
+	if err != nil {
+		logger.V(5).WithValues("err", err).Info("can not connect to address")
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		logger.V(5).WithValues("statusCode", res.StatusCode).Info("status code on request")
+		return nil, fmt.Errorf("status code %d", res.StatusCode)
+	}
+
+	conn := rwconn.NewConn(res.Body, pw)
+	return conn, nil
+}
+
+func (ln *Listener) grabConn() {
+	// create a new connection
+	c, err := ln.dial()
+	if err != nil {
+		klog.Background().V(5).WithValues("err", err).Info("can not create connection")
+		ln.sendMessage(controlMsg{Command: "pickup-failed", ConnPath: "", Err: err.Error()})
+		return
+	}
+
+	// send the connection to the listener
+	select {
+	case <-ln.donec:
+		return
+	default:
+		select {
+		case ln.connc <- c:
+		case <-ln.donec:
+			return
+		}
+	}
+}
+
+// Accept blocks and returns a new connection, or an error.
+func (ln *Listener) Accept() (net.Conn, error) {
+	c, ok := <-ln.connc
+	if !ok {
+		ln.mu.Lock()
+		err, closed := ln.readErr, ln.closed
+		ln.mu.Unlock()
+		if err != nil && !closed {
+			return nil, fmt.Errorf("tunneler: Listener closed; %w", err)
+		}
+		return nil, ErrListenerClosed
+	}
+	klog.Background().V(5).Info("accepted connection")
+	return c, nil
+}
+
+// ErrListenerClosed is returned by Accept after Close has been called.
+var ErrListenerClosed = errors.New("tunneler: Listener closed")
+
+// Close closes the Listener, making future Accept calls return an
+// error.
+func (ln *Listener) Close() error {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+	if ln.closed {
+		return nil
+	}
+	ln.closed = true
+	close(ln.connc)
+	close(ln.donec)
+	ln.sc.Close()
+	return nil
+}
+
+// Addr returns a dummy address. This exists only to conform to the
+// net.Listener interface.
+func (ln *Listener) Addr() net.Addr { return connAddr{} }
+
+// configureHTTP2Transport enable ping to avoid issues with stale connections.
+func configureHTTP2Transport(client *http.Client) error {
+	t, ok := client.Transport.(*http.Transport)
+	if !ok {
+		// can't get the transport it will fail later if not http2 supported
+		return nil
+	}
+
+	if t.TLSClientConfig == nil {
+		return fmt.Errorf("only TLS supported")
+	}
+
+	for _, v := range t.TLSClientConfig.NextProtos {
+		// http2 already configured
+		if v == "h2" {
+			return nil
+		}
+	}
+
+	t2, err := http2.ConfigureTransports(t)
+	if err != nil {
+		return err
+	}
+
+	t2.ReadIdleTimeout = time.Duration(30) * time.Second
+	t2.PingTimeout = time.Duration(15) * time.Second
+	return nil
+}
+
+type connAddr struct{}
+
+func (connAddr) Network() string { return "rwconn" }
+func (connAddr) String() string  { return "rwconn" }

--- a/pkg/tunneler/listener_test.go
+++ b/pkg/tunneler/listener_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Based on https://github.com/golang/build/blob/master/revdial/v2/revdial.go
+package tunneler
+
+import "testing"
+
+func Test_SyncerTunnelURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		ws      string
+		target  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "valid",
+			host:   "https://host:9443/base",
+			ws:     "myws",
+			target: "syncer001",
+			want:   "https://host:9443/base/clusters/myws/apis/workload.kcp.io/v1alpha1/synctargets/syncer001",
+		},
+		{
+			name:    "invalid host scheme",
+			host:    "http://host:9443/base",
+			ws:      "myws",
+			target:  "syncer001",
+			wantErr: true,
+		},
+		{
+			name:    "invalid host port",
+			host:    "https://host:port/base",
+			ws:      "myws",
+			target:  "syncer001",
+			wantErr: true,
+		},
+		{
+			name:    "empty ws",
+			host:    "https://host:9443/base",
+			ws:      "",
+			target:  "syncer002",
+			wantErr: true,
+		},
+
+		{
+			name:    "empty target",
+			host:    "https://host:9443/base",
+			ws:      "myws",
+			target:  "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SyncerTunnelURL(tt.host, tt.ws, tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SyncerTunnelURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SyncerTunnelURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tunneler/podsubresourceproxy_handler.go
+++ b/pkg/tunneler/podsubresourceproxy_handler.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/kcp-dev/client-go/dynamic"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpinformers "github.com/kcp-dev/kcp/sdk/client/informers/externalversions"
+)
+
+var (
+	errorScheme = runtime.NewScheme()
+	errorCodecs = serializer.NewCodecFactory(errorScheme)
+)
+
+func init() {
+	errorScheme.AddUnversionedTypes(metav1.Unversioned,
+		&metav1.Status{},
+	)
+}
+
+// WithPodSubresourceProxying proxies the POD subresource requests using the syncer tunneler.
+func (tn *tunneler) WithPodSubresourceProxying(apiHandler http.Handler, kcpclient dynamic.ClusterInterface, kcpInformer kcpinformers.SharedInformerFactory, globalKcpInformer kcpinformers.SharedInformerFactory) http.Handler {
+	syncTargetInformer, err := kcpInformer.ForResource(workloadv1alpha1.SchemeGroupVersion.WithResource("synctargets"))
+	if err != nil {
+		panic(err)
+	}
+	globalSyncTargetInformer, err := globalKcpInformer.ForResource(workloadv1alpha1.SchemeGroupVersion.WithResource("synctargets"))
+	if err != nil {
+		panic(err)
+	}
+
+	return &podSubresourceProxyHandler{
+		proxyFunc:  tn.Proxy,
+		apiHandler: apiHandler,
+		getPodByName: func(ctx context.Context, cluster logicalcluster.Name, namespace, podName string) (*corev1.Pod, error) {
+			unstr, err := kcpclient.Cluster(cluster.Path()).Resource(corev1.SchemeGroupVersion.WithResource("pods")).Namespace(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			pod := &corev1.Pod{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstr.Object, pod); err != nil {
+				return nil, err
+			}
+			return pod, nil
+		},
+		getSyncTargetBySynctargetKey: func(ctx context.Context, synctargetKey string) (*workloadv1alpha1.SyncTarget, error) {
+			synctargets, err := indexers.ByIndexWithFallback[*workloadv1alpha1.SyncTarget](syncTargetInformer.Informer().GetIndexer(), globalSyncTargetInformer.Informer().GetIndexer(), indexers.SyncTargetsBySyncTargetKey, synctargetKey)
+			if err != nil {
+				return nil, err
+			}
+			if len(synctargets) != 1 {
+				return nil, fmt.Errorf("expected 1 synctarget for key %q, got %d", synctargetKey, len(synctargets))
+			}
+			return synctargets[0], nil
+		},
+	}
+}
+
+type podSubresourceProxyHandler struct {
+	proxyFunc                    func(clusterName logicalcluster.Name, syncerName string, rw http.ResponseWriter, req *http.Request)
+	apiHandler                   http.Handler
+	getPodByName                 func(ctx context.Context, cluster logicalcluster.Name, namespace, podName string) (*corev1.Pod, error)
+	getSyncTargetBySynctargetKey func(ctx context.Context, synctargetKey string) (*workloadv1alpha1.SyncTarget, error)
+}
+
+func (b *podSubresourceProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logger := klog.FromContext(req.Context())
+	cluster := request.ClusterFrom(req.Context())
+	ctx := req.Context()
+	requestInfo, ok := request.RequestInfoFrom(ctx)
+	// If the requestInfo is not present, just return.
+	if !ok {
+		b.apiHandler.ServeHTTP(w, req)
+		return
+	}
+
+	if !requestInfo.IsResourceRequest {
+		b.apiHandler.ServeHTTP(w, req)
+		return
+	}
+
+	if cluster.Name.Empty() {
+		b.apiHandler.ServeHTTP(w, req)
+		return
+	}
+
+	if requestInfo.Resource != "pods" || requestInfo.Subresource == "" {
+		b.apiHandler.ServeHTTP(w, req)
+		return
+	}
+
+	namespace := requestInfo.Namespace
+	podName := requestInfo.Name
+	subresource := requestInfo.Subresource
+
+	// If something is empty, just return..
+	if namespace == "" || podName == "" || subresource == "" {
+		b.apiHandler.ServeHTTP(w, req)
+		return
+	}
+
+	// Check if the subresource is valid, for PODs we support exec, log, portforward, proxy , attach and ephemeralcontainers.
+	if subresource != "exec" && subresource != "log" && subresource != "portforward" && subresource != "proxy" && subresource != "attach" && subresource != "ephemeralcontainers" {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewBadRequest(fmt.Sprintf("invalid subresource or not implemented %q", subresource)),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+
+	// Now let's start the proxying
+	logger.Info("proxying pod subresource", "namespace", namespace, "podName", podName, "subresource", subresource)
+
+	pod, err := b.getPodByName(req.Context(), cluster.Name, namespace, podName)
+	if apierrors.IsNotFound(err) {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "pods"}, podName),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+	if err != nil {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+
+	// Let's get the synctargetKey
+	var synctargetKey string
+	for k, v := range pod.GetLabels() {
+		if strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) {
+			if v == string(workloadv1alpha1.ResourceStateUpsync) {
+				synctargetKey = strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix)
+				break
+			}
+		}
+	}
+	if synctargetKey == "" {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewBadRequest(fmt.Sprintf("pod %q is not upsynced", podName)),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+
+	synctarget, err := b.getSyncTargetBySynctargetKey(req.Context(), synctargetKey)
+	if apierrors.IsNotFound(err) {
+		logger.Error(err, "synctarget not found when trying to proxy subresource", "synctargetKey", synctargetKey, "subresource", subresource, "podName", podName)
+		responsewriters.ErrorNegotiated(
+			apierrors.NewServiceUnavailable(fmt.Sprintf("subresource %q is not available right now for pod %q", subresource, podName)),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+	if err != nil {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+
+	// Let's find the downstream namespace for the POD
+	// TODO(jmprusi): This should rely on an annotation in the resource instead of calculating the downstreamNamespace as
+	//                there's a possibility that the namespace name is different from the calculated one (migrations, etc).
+	downstreamNamespace, err := shared.PhysicalClusterNamespaceName(shared.NamespaceLocator{
+		SyncTarget: shared.SyncTargetLocator{
+			ClusterName: logicalcluster.From(synctarget).String(),
+			Name:        synctarget.GetName(),
+			UID:         synctarget.GetUID(),
+		},
+		ClusterName: cluster.Name,
+		Namespace:   namespace,
+	})
+	if err != nil {
+		logger.Error(err, "unable to find downstream namespace for pod", "namespace", namespace, "podName", podName)
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+
+	// Rewrite the path to point to the SyncerTunnel proxy path.
+	podDownstreamURL, err := podSubresourceURL(downstreamNamespace, podName, subresource)
+	if err != nil {
+		logger.Error(err, "unable to get syncer tunnel proxy path")
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(err),
+			errorCodecs, schema.GroupVersion{}, w, req,
+		)
+		return
+	}
+	// Set the URL path to the calculated
+	req.URL.Path = podDownstreamURL.Path
+
+	b.proxyFunc(logicalcluster.From(synctarget), synctarget.GetName(), w, req)
+}
+
+func podSubresourceURL(downstreamNamespaceName, podName, subresource string) (*url.URL, error) {
+	if downstreamNamespaceName == "" || podName == "" || subresource == "" {
+		return nil, fmt.Errorf("invalid tunnel path: downstreamNamespaceName=%q, podName=%q, subresource=%q", downstreamNamespaceName, podName, subresource)
+	}
+	proxyPath, err := url.JoinPath("/api/v1/namespaces", downstreamNamespaceName, "pods", podName, subresource)
+	if err != nil {
+		return nil, err
+	}
+	return url.Parse(proxyPath)
+}
+
+// Proxy proxies the request to the syncer identified by the cluster and syncername.
+func (tn *tunneler) Proxy(clusterName logicalcluster.Name, syncerName string, rw http.ResponseWriter, req *http.Request) {
+	d := tn.getDialer(clusterName, syncerName)
+	if d == nil || isClosedChan(d.Done()) {
+		rw.Header().Set("Retry-After", "1")
+		http.Error(rw, "syncer tunnels: tunnel closed", http.StatusServiceUnavailable)
+		return
+	}
+
+	target, err := url.Parse("http://" + syncerName)
+	if err != nil {
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = &http.Transport{
+		Proxy:               nil,    // no proxies
+		DialContext:         d.Dial, // use a reverse connection
+		ForceAttemptHTTP2:   false,  // this is a tunneled connection
+		DisableKeepAlives:   true,   // one connection per reverse connection
+		MaxIdleConnsPerHost: -1,
+	}
+
+	proxy.ServeHTTP(rw, req)
+}

--- a/pkg/tunneler/podsubresourceproxy_handler_test.go
+++ b/pkg/tunneler/podsubresourceproxy_handler_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+func TestPodSubresourceProxyingHandler(t *testing.T) {
+	tests := map[string]struct {
+		subresource         string
+		workspace           string
+		podExists           bool
+		podIsUpsynced       bool
+		syncTargetExists    bool
+		synctargetWorkspace string
+		expectedError       string
+		expectedProxiedPath string
+	}{
+		"valid request with existing pod and synctarget, pod and synctarget on the same workspace": {
+			subresource:         "exec",
+			workspace:           "cluster1",
+			podExists:           true,
+			syncTargetExists:    true,
+			podIsUpsynced:       true,
+			synctargetWorkspace: "cluster1",
+			expectedProxiedPath: "/api/v1/namespaces/kcp-xwdjipyflk7g/pods/foo/exec",
+		},
+		"valid request with existing pod and synctarget, pod and synctarget on different workspaces": {
+			subresource:         "exec",
+			workspace:           "cluster1",
+			podExists:           true,
+			podIsUpsynced:       true,
+			syncTargetExists:    true,
+			synctargetWorkspace: "cluster2",
+			expectedProxiedPath: "/api/v1/namespaces/kcp-1kdcree89tsy/pods/foo/exec",
+		},
+		"non existing pod": {
+			subresource:   "exec",
+			workspace:     "cluster1",
+			podExists:     false,
+			expectedError: "404 Not Found",
+		},
+		"non existing synctarget": {
+			subresource:      "exec",
+			workspace:        "cluster1",
+			podExists:        true,
+			podIsUpsynced:    true,
+			syncTargetExists: false,
+			expectedError:    "503 Service Unavailable",
+		},
+		"valid request but pod is not upsynced": {
+			subresource:      "exec",
+			workspace:        "cluster1",
+			podExists:        true,
+			podIsUpsynced:    false,
+			syncTargetExists: true,
+			expectedError:    "400 Bad Request",
+		},
+		"invalid subresource, expect error": {
+			subresource:   "invalid",
+			workspace:     "cluster1",
+			podExists:     true,
+			expectedError: "400 Bad Request",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			proxiedPath := ""
+			handler := &podSubresourceProxyHandler{
+				proxyFunc: func(cluster logicalcluster.Name, syncTargetName string, w http.ResponseWriter, req *http.Request) {
+					proxiedPath = req.URL.Path
+					if tc.syncTargetExists && tc.podExists {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintln(w, nil)
+					}
+				},
+				apiHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
+				getPodByName: func(ctx context.Context, cluster logicalcluster.Name, namespace, podName string) (*corev1.Pod, error) {
+					if !tc.podExists {
+						return nil, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, podName)
+					}
+					stateLabel := "Upsync"
+					if !tc.podIsUpsynced {
+						stateLabel = "Synced"
+					}
+					return &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      podName,
+							Namespace: namespace,
+							Labels: map[string]string{
+								"state.workload.kcp.io/ABCDEFGHIJKL": stateLabel,
+							},
+						},
+					}, nil
+				},
+				getSyncTargetBySynctargetKey: func(ctx context.Context, synctargetKey string) (*workloadv1alpha1.SyncTarget, error) {
+					if !tc.syncTargetExists {
+						return nil, errors.NewNotFound(schema.GroupResource{Resource: "synctargets"}, synctargetKey)
+					}
+					return &workloadv1alpha1.SyncTarget{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "synctarget1",
+							Annotations: map[string]string{
+								"workload.kcp.io/key": "ABCDEFGHIJKL",
+								"kcp.io/cluster":      tc.synctargetWorkspace,
+							},
+						},
+					}, nil
+				},
+			}
+			namespace := "default"
+			podName := "foo"
+			path, err := url.JoinPath("/api/v1/namespaces" + namespace + "/pods/" + podName + "/" + tc.subresource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := httptest.NewRequest(http.MethodGet, path, nil).WithContext(request.WithRequestInfo(
+				request.WithCluster(ctx, request.Cluster{Name: logicalcluster.Name(tc.workspace)}),
+				&request.RequestInfo{
+					Verb:              "get",
+					Resource:          "pods",
+					APIGroup:          "",
+					APIVersion:        "v1",
+					Name:              podName,
+					Namespace:         namespace,
+					IsResourceRequest: true,
+					Subresource:       tc.subresource,
+					Path:              path,
+				}))
+
+			rw := httptest.NewRecorder()
+			handler.ServeHTTP(rw, r)
+			result := rw.Result()
+			defer result.Body.Close()
+			bytes, err := io.ReadAll(result.Body)
+			require.NoError(t, err, "Request body cannot be read")
+			if tc.expectedError != "" {
+				require.Equal(t, tc.expectedError, result.Status, "Unexpected status code: %s", string(bytes))
+				return
+			}
+			require.Equal(t, http.StatusOK, result.StatusCode, "Unexpected status code: %s", string(bytes))
+			if tc.expectedProxiedPath != "" {
+				require.Equal(t, tc.expectedProxiedPath, proxiedPath, "Unexpected proxied path")
+			}
+		})
+	}
+}

--- a/pkg/tunneler/syncertunnel_handler.go
+++ b/pkg/tunneler/syncertunnel_handler.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/aojea/rwconn"
+
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+// WithSyncerTunnelHandler adds an HTTP Handler that handles reverse connections via the tunnel subresource:
+//
+// https://host/clusters/<ws>/apis/workload.kcp.io/v1alpha1/synctargets/<name>/tunnel establish reverse connections and queue them so it can be consumed by the dialer
+func (tn *tunneler) WithSyncerTunnelHandler(apiHandler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := klog.FromContext(ctx)
+
+		ri, ok := genericapirequest.RequestInfoFrom(ctx)
+		if !ok {
+			apiHandler.ServeHTTP(w, r)
+			return
+		}
+
+		if !ri.IsResourceRequest ||
+			ri.Resource != "synctargets" ||
+			ri.Subresource != "tunnel" ||
+			ri.APIGroup != workloadv1alpha1.SchemeGroupVersion.Group ||
+			ri.APIVersion != workloadv1alpha1.SchemeGroupVersion.Version ||
+			ri.Name == "" {
+			apiHandler.ServeHTTP(w, r)
+			return
+		}
+
+		cluster, err := genericapirequest.ValidClusterFrom(ctx)
+		if err != nil {
+			apiHandler.ServeHTTP(w, r)
+			return
+		}
+
+		clusterName := cluster.Name
+		syncerName := ri.Name
+
+		logger = logger.WithValues("cluster", clusterName, "syncerName", syncerName, "action", "tunnel")
+		logger.V(5).Info("tunneler connection received")
+		d := tn.getDialer(clusterName, syncerName)
+		// First flush response headers
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "flusher not implemented", http.StatusInternalServerError)
+			return
+		}
+
+		// first connection to register the dialer and start the control loop
+		fw := &flushWriter{w: w, f: flusher}
+		doneCh := make(chan struct{})
+		conn := rwconn.NewConn(r.Body, fw, rwconn.SetWriteDelay(500*time.Millisecond), rwconn.SetCloseHook(func() {
+			// exit the handler
+			close(doneCh)
+		}))
+		if d == nil || isClosedChan(d.Done()) {
+			// start clean
+			tn.deleteDialer(clusterName, syncerName)
+			tn.createDialer(clusterName, syncerName, conn)
+			// start control loop
+			select {
+			case <-r.Context().Done():
+				conn.Close()
+			case <-doneCh:
+			}
+			logger.V(5).Info("stopped tunnel control connection")
+			return
+		}
+		logger.Info("Creating tunnel connection", "clustername", clusterName, "syncername", syncerName)
+		// create a reverse connection
+		logger.V(5).Info("tunnel connection started")
+		select {
+		case d.incomingConn <- conn:
+		case <-d.Done():
+			http.Error(w, "syncer tunnels: tunnel closed", http.StatusInternalServerError)
+			return
+		}
+		// keep the handler alive until the connection is closed
+		select {
+		case <-r.Context().Done():
+			conn.Close()
+		case <-doneCh:
+		}
+		logger.V(5).Info("tunnel connection done", "remoteAddr", r.RemoteAddr)
+	}
+}

--- a/pkg/tunneler/tunnel.go
+++ b/pkg/tunneler/tunnel.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+)
+
+const (
+	tunnelSubresourcePath = "tunnel"
+)
+
+type controlMsg struct {
+	Command  string `json:"command,omitempty"`  // "keep-alive", "conn-ready", "pickup-failed"
+	ConnPath string `json:"connPath,omitempty"` // conn pick-up URL path for "conn-url", "pickup-failed"
+	Err      string `json:"err,omitempty"`
+}
+
+type key struct {
+	clusterName    logicalcluster.Name
+	syncTargetName string
+}
+
+// tunneler contains a pool of Dialers to create reverse connections
+// based on the cluster and syncer name.
+type tunneler struct {
+	mu   sync.Mutex
+	pool map[key]*Dialer
+}
+
+func NewTunneler() *tunneler {
+	return &tunneler{
+		pool: make(map[key]*Dialer),
+		mu:   sync.Mutex{},
+	}
+}
+
+// getDialer returns a reverse dialer for the id.
+func (tn *tunneler) getDialer(clusterName logicalcluster.Name, syncTargetName string) *Dialer {
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
+	id := key{clusterName, syncTargetName}
+	return tn.pool[id]
+}
+
+// createDialer creates a reverse dialer with id
+// it's a noop if a dialer already exists.
+func (tn *tunneler) createDialer(clusterName logicalcluster.Name, syncTargetName string, conn net.Conn) *Dialer {
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
+	id := key{clusterName, syncTargetName}
+	if d, ok := tn.pool[id]; ok {
+		return d
+	}
+	d := NewDialer(conn)
+	tn.pool[id] = d
+	return d
+}
+
+// deleteDialer deletes the reverse dialer for a given id.
+func (tn *tunneler) deleteDialer(clusterName logicalcluster.Name, syncTargetName string) {
+	tn.mu.Lock()
+	defer tn.mu.Unlock()
+	id := key{clusterName, syncTargetName}
+	delete(tn.pool, id)
+}
+
+// syncerTunnelURL builds the destination url with the Dialer expected format of the URL.
+func SyncerTunnelURL(host, ws, target string) (string, error) {
+	if target == "" || ws == "" {
+		return "", fmt.Errorf("target or ws can not be empty")
+	}
+	hostURL, err := url.Parse(host)
+	if err != nil || hostURL.Scheme != "https" || hostURL.Host == "" {
+		return "", fmt.Errorf("wrong url format, expected https://host<:port>/<path>: %w", err)
+	}
+	return url.JoinPath(hostURL.String(), "clusters", ws, "apis", workloadv1alpha1.SchemeGroupVersion.String(), "synctargets", target)
+}
+
+// flushWriter.
+type flushWriter struct {
+	w io.Writer
+	f http.Flusher
+}
+
+func (w *flushWriter) Write(data []byte) (int, error) {
+	n, err := w.w.Write(data)
+	w.f.Flush()
+	return n, err
+}
+
+func (w *flushWriter) Close() error {
+	return nil
+}
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/tunneler/tunnel_test.go
+++ b/pkg/tunneler/tunnel_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunneler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncerTunnelURL(t *testing.T) {
+	tests := map[string]struct {
+		host        string
+		workspace   string
+		target      string
+		expected    string
+		expectError bool
+	}{
+		"valid host, no ports": {
+			host:      "https://example.com",
+			workspace: "root:testing:testing",
+			target:    "cluster1",
+			expected:  "https://example.com/clusters/root:testing:testing/apis/workload.kcp.io/v1alpha1/synctargets/cluster1",
+		},
+		"valid host, with ports": {
+			host:      "https://example.com:443",
+			workspace: "root:testing:testing",
+			target:    "cluster1",
+			expected:  "https://example.com:443/clusters/root:testing:testing/apis/workload.kcp.io/v1alpha1/synctargets/cluster1",
+		},
+		"invalid host": {
+			host:        "example.com:443:443",
+			workspace:   "root:testing:testing",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"invalid host, no scheme": {
+			host:        "example.com:443:443",
+			workspace:   "root:testing:testing",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"invalid host, no scheme, no port": {
+			host:        "example.com:443:443",
+			workspace:   "root:testing:testing",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"invalid host, no scheme, no port, no host": {
+			host:        ":443:443",
+			workspace:   "root:testing:testing",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"empty host": {
+			host:        "",
+			workspace:   "root:testing:testing",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"empty workspace": {
+			host:        "example.com:443",
+			workspace:   "",
+			target:      "cluster1",
+			expectError: true,
+		},
+		"empty target": {
+			host:        "example.com:443",
+			workspace:   "root:testing:testing",
+			target:      "",
+			expectError: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := SyncerTunnelURL(tc.host, tc.workspace, tc.target)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, got)
+			}
+		})
+	}
+}

--- a/test/e2e/syncer/configmap-admin-role.yaml
+++ b/test/e2e/syncer/configmap-admin-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: configmap-admin
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - "*"

--- a/test/e2e/syncer/configmap-admin-rolebinding.yaml
+++ b/test/e2e/syncer/configmap-admin-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default:configmap-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: configmap-admin
+subjects:
+  - kind: ServiceAccount
+    name: default

--- a/test/e2e/syncer/deployment.yaml
+++ b/test/e2e/syncer/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+   name: syncer-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: busybox
+          image: ghcr.io/distroless/busybox:latest
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Going to sleep"
+              tail -f /dev/null

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/test/e2e/syncer/dns/workspace1"
+	"github.com/kcp-dev/kcp/test/e2e/syncer/dns/workspace2"
+)
+
+func TestDNSResolution(t *testing.T) {
+	t.Skip("Test is flaky, and we are going to remove the syncer soon anyway")
+
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		t.Skip("Test requires a pcluster")
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	upstreamConfig := upstreamServer.BaseConfig(t)
+
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("location"), framework.TODO_WithoutMultiShardSupport())
+
+	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-1"), framework.TODO_WithoutMultiShardSupport())
+	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-2"), framework.TODO_WithoutMultiShardSupport())
+
+	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
+		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+	syncer.WaitForSyncTargetReady(ctx, t)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)
+	require.NoError(t, err)
+
+	t.Logf("Bind workload workspace 1 to location workspace")
+	framework.NewBindCompute(t, workloadWorkspace1Path, upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWorkspacePath),
+	).Bind(t)
+
+	t.Logf("Bind workload workspace 2 to location workspace")
+	framework.NewBindCompute(t, workloadWorkspace2Path, upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWorkspacePath),
+	).Bind(t)
+
+	err = framework.CreateResources(ctx, workspace1.FS, upstreamConfig, workloadWorkspace1Path)
+	require.NoError(t, err)
+
+	err = framework.CreateResources(ctx, workspace2.FS, upstreamConfig, workloadWorkspace2Path)
+	require.NoError(t, err)
+
+	downstreamWS1NS1 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace1.Spec.Cluster), "dns-ws1-ns1")
+	t.Logf("Downstream namespace 1 in workspace 1 is %s", downstreamWS1NS1)
+
+	downstreamWS1NS2 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace1.Spec.Cluster), "dns-ws1-ns2")
+	t.Logf("Downstream namespace 2 in workspace 1 is %s", downstreamWS1NS2)
+
+	downstreamWS2NS1 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace2.Spec.Cluster), "dns-ws2-ns1")
+	t.Logf("Downstream namespace 1 in workspace 2 is %s", downstreamWS2NS1)
+
+	t.Log("Checking network policies have been created")
+	framework.Eventually(t, func() (success bool, reason string) {
+		np, err := downstreamKubeClient.NetworkingV1().NetworkPolicies(syncer.SyncerID).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting network policies: %v\n", err)
+		}
+		if len(np.Items) != 2 {
+			return false, fmt.Sprintf("expecting 2 network policies, got: %d\n", len(np.Items))
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Network policies haven't been created")
+
+	t.Log("Checking fully qualified DNS name resolves")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-fully-qualified", "PING svc.dns-ws1-ns1.svc.cluster.local ("),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was not resolved")
+
+	t.Log("Checking not qualified DNS name resolves")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-not-qualified", "PING svc ("),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was not resolved")
+
+	t.Log("Checking DNS name resolves across namespaces in same workspace")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS2, "ping-across-namespace", "PING svc.dns-ws1-ns1 ("),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was not resolved")
+
+	t.Log("Checking DNS name does not resolve across workspaces")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS2NS1, "ping-fully-qualified-fail", "ping: bad"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was resolved")
+
+	t.Log("Change ping-fully-qualified deployment DNS config to use workspace 2 nameserver and check the DNS name does not resolve")
+	dnsServices, err := downstreamKubeClient.CoreV1().Services(syncer.SyncerID).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.True(t, len(dnsServices.Items) >= 2)
+
+	deployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Get(ctx, "ping-fully-qualified", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	existingDNSIP := deployment.Spec.Template.Spec.DNSConfig.Nameservers[0]
+	newDNSIP := ""
+	for _, svc := range dnsServices.Items {
+		if strings.HasPrefix(svc.Name, "kcp-dns-") {
+			if svc.Spec.ClusterIP != existingDNSIP {
+				newDNSIP = svc.Spec.ClusterIP
+				break
+			}
+		}
+	}
+	require.NotEmpty(t, newDNSIP, "could not find another DNS service")
+	deployment.Spec.Template.Spec.DNSConfig.Nameservers[0] = newDNSIP
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Get(ctx, "ping-fully-qualified", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		deployment.Spec.Template.Spec.DNSConfig.Nameservers[0] = newDNSIP
+		_, err = downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Update(ctx, deployment, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err)
+
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-fully-qualified", "ping: bad"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was resolved")
+}
+
+//nolint:unused
+func checkLogs(ctx context.Context, t *testing.T, downstreamKubeClient *kubernetes.Clientset, downstreamNamespace, containerName, expectedPrefix string) func() (success bool, reason string) {
+	t.Helper()
+
+	return func() (success bool, reason string) {
+		pods, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("Error getting pods: %v", err)
+		}
+
+		for _, pod := range pods.Items {
+			for _, c := range pod.Spec.Containers {
+				if c.Name == containerName {
+					res, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+						Container: c.Name,
+					}).DoRaw(ctx)
+
+					if err != nil {
+						return false, fmt.Sprintf("Failed to get logs for pod %s/%s container %s: %v", pod.Namespace, pod.Name, c.Name, err)
+					}
+
+					for _, line := range strings.Split(string(res), "\n") {
+						t.Logf("Pod %s/%s container %s: %s", pod.Namespace, pod.Name, c.Name, line)
+						if strings.HasPrefix(line, expectedPrefix) {
+							return true, ""
+						}
+					}
+				}
+			}
+		}
+		return false, "no pods"
+	}
+}

--- a/test/e2e/syncer/dns/workspace1/0-namespace1.yaml
+++ b/test/e2e/syncer/dns/workspace1/0-namespace1.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns-ws1-ns1

--- a/test/e2e/syncer/dns/workspace1/0-namespace2.yaml
+++ b/test/e2e/syncer/dns/workspace1/0-namespace2.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns-ws1-ns2

--- a/test/e2e/syncer/dns/workspace1/embed.go
+++ b/test/e2e/syncer/dns/workspace1/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace1
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/dns/workspace1/ping-across-namespace.yaml
+++ b/test/e2e/syncer/dns/workspace1/ping-across-namespace.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-across-namespace
+  namespace: dns-ws1-ns2
+spec:
+  selector:
+    matchLabels:
+      app: ping-across-namespace
+  template:
+    metadata:
+      labels:
+        app: ping-across-namespace
+    spec:
+      containers:
+      - name: ping-across-namespace
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping svc.dns-ws1-ns1; do sleep 1; done']

--- a/test/e2e/syncer/dns/workspace1/ping-fully-qualified.yaml
+++ b/test/e2e/syncer/dns/workspace1/ping-fully-qualified.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-fully-qualified
+  namespace: dns-ws1-ns1
+spec:
+  selector:
+    matchLabels:
+      app: ping-fully-qualified
+  template:
+    metadata:
+      labels:
+        app: ping-fully-qualified
+    spec:
+      containers:
+      - name: ping-fully-qualified
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping svc.dns-ws1-ns1.svc.cluster.local; do sleep 1; done']

--- a/test/e2e/syncer/dns/workspace1/ping-not-qualified.yaml
+++ b/test/e2e/syncer/dns/workspace1/ping-not-qualified.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-not-qualified
+  namespace: dns-ws1-ns1
+spec:
+  selector:
+    matchLabels:
+      app: ping-not-qualified
+  template:
+    metadata:
+      labels:
+        app: ping-not-qualified
+    spec:
+      containers:
+      - name: ping-not-qualified
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping svc; do sleep 1; done']

--- a/test/e2e/syncer/dns/workspace1/service.yaml
+++ b/test/e2e/syncer/dns/workspace1/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+  namespace: dns-ws1-ns1
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/test/e2e/syncer/dns/workspace2/0-namespace.yaml
+++ b/test/e2e/syncer/dns/workspace2/0-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns-ws2-ns1

--- a/test/e2e/syncer/dns/workspace2/embed.go
+++ b/test/e2e/syncer/dns/workspace2/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace2
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/dns/workspace2/ping-fully-qualified-fail.yaml
+++ b/test/e2e/syncer/dns/workspace2/ping-fully-qualified-fail.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-fully-qualified-fail
+  namespace: dns-ws2-ns1
+spec:
+  selector:
+    matchLabels:
+      app: ping-fully-qualified-fail
+  template:
+    metadata:
+      labels:
+        app: ping-fully-qualified-fail
+    spec:
+      containers:
+      - name: ping-fully-qualified-fail
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping svc.dns-ws1-ns1.svc.cluster.local; do sleep 1; done']

--- a/test/e2e/syncer/endpoints/deployment-with-upsync.yaml
+++ b/test/e2e/syncer/endpoints/deployment-with-upsync.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: with-endpoints-upsync
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: with-endpoints-upsync
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: with-endpoints-upsync
+    spec:
+      containers:
+        - name: busybox
+          image: ghcr.io/distroless/busybox:latest
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Going to sleep"
+              tail -f /dev/null

--- a/test/e2e/syncer/endpoints/deployment-without-upsync.yaml
+++ b/test/e2e/syncer/endpoints/deployment-without-upsync.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: without-endpoints-upsync
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: without-endpoints-upsync
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: without-endpoints-upsync
+    spec:
+      containers:
+        - name: busybox
+          image: ghcr.io/distroless/busybox:latest
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Going to sleep"
+              tail -f /dev/null

--- a/test/e2e/syncer/endpoints/embed.go
+++ b/test/e2e/syncer/endpoints/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/endpoints/endpoints_test.go
+++ b/test/e2e/syncer/endpoints/endpoints_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestEndpointsUpsyncing(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		t.Skip("Test requires a pcluster")
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	upstreamConfig := upstreamServer.BaseConfig(t)
+
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("location"), framework.TODO_WithoutMultiShardSupport())
+
+	workloadWorkspacePath, workloadWorkspace := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload"), framework.TODO_WithoutMultiShardSupport())
+
+	upstreamKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(upstreamConfig)
+	require.NoError(t, err)
+
+	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
+		framework.WithSyncedUserWorkspaces(workloadWorkspace),
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+	syncer.WaitForSyncTargetReady(ctx, t)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)
+	require.NoError(t, err)
+
+	t.Logf("Bind workload workspace to location workspace")
+	framework.NewBindCompute(t, workloadWorkspacePath, upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWorkspacePath),
+	).Bind(t)
+
+	err = framework.CreateResources(ctx, FS, upstreamConfig, workloadWorkspacePath)
+	require.NoError(t, err)
+
+	downstreamNamespace := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace.Spec.Cluster), "default")
+	t.Logf("Downstream namespace is %s", downstreamNamespace)
+
+	t.Log("Checking services have been created downstream")
+	framework.Eventually(t, func() (success bool, reason string) {
+		services, err := downstreamKubeClient.CoreV1().Services(downstreamNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting services: %v\n", err)
+		}
+		if len(services.Items) != 2 {
+			return false, fmt.Sprintf("expecting 2 services, got: %d\n", len(services.Items))
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Services haven't been created")
+
+	t.Log("Checking endpoints have been created downstream")
+	framework.Eventually(t, func() (success bool, reason string) {
+		endpoints, err := downstreamKubeClient.CoreV1().Endpoints(downstreamNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting endpoints: %v\n", err)
+		}
+		if len(endpoints.Items) != 2 {
+			return false, fmt.Sprintf("expecting 2 endpoints, got: %d\n", len(endpoints.Items))
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Endpoints haven't been created")
+
+	t.Log("Checking that only 1 endpoint has been upsynced upstream")
+	framework.Eventually(t, func() (success bool, reason string) {
+		endpoints, err := upstreamKubeClusterClient.Cluster(workloadWorkspacePath).CoreV1().Endpoints("default").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting endpoints: %v\n", err)
+		}
+		if len(endpoints.Items) != 1 {
+			return false, fmt.Sprintf("expecting 1 endpoint, got: %d\n", len(endpoints.Items))
+		}
+
+		if endpoints.Items[0].Name != "with-endpoints-upsync" {
+			return false, fmt.Sprintf("expecting endpoint with name 'with-endpoints-upsync', got: %s\n", endpoints.Items[0].Name)
+		}
+
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Endpoints hasn't been upsynced")
+}

--- a/test/e2e/syncer/endpoints/service-with-upsync.yaml
+++ b/test/e2e/syncer/endpoints/service-with-upsync.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: with-endpoints-upsync
+  namespace: default
+  annotations:
+    experimental.workload.kcp.io/upsync-derived-resources: endpoints
+spec:
+  selector:
+    app.kubernetes.io/name: with-endpoints-upsync
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/test/e2e/syncer/endpoints/service-without-upsync.yaml
+++ b/test/e2e/syncer/endpoints/service-without-upsync.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: without-endpoints-upsync
+  namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: without-endpoints-upsync
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/test/e2e/syncer/in-cluster-config-test-deployment.yaml
+++ b/test/e2e/syncer/in-cluster-config-test-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: icc-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: icc-test
+  template:
+    metadata:
+      labels:
+        app: icc-test
+    spec:
+      containers:
+        - name: icc-test
+          image: ghcr.io/kcp-dev/kcp/kcp-test-image:main
+          env:
+            - name: CONFIGMAP_NAME
+              value: expected-configmap
+          # TODO(geoberle) once the test image contains more test clients, we need to define args for the entrypoint or something similar

--- a/test/e2e/syncer/multishard/multishard_test.go
+++ b/test/e2e/syncer/multishard/multishard_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multishard
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	appsv1apply "k8s.io/client-go/applyconfigurations/apps/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/test/e2e/syncer/multishard/workspace1"
+	"github.com/kcp-dev/kcp/test/e2e/syncer/multishard/workspace2"
+)
+
+// TestSyncingFromMultipleShards ensures that the syncer can effectively sync from several workspaces hosted on distinct shards
+// with distinct virtual workspace URLs.
+func TestSyncingFromMultipleShards(t *testing.T) {
+	t.Skip("Test is flaky, and we are going to remove the syncer soon anyway")
+
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	upstreamServer := framework.SharedKcpServer(t)
+	upstreamConfig := upstreamServer.BaseConfig(t)
+
+	shardNames := upstreamServer.ShardNames()
+	if len(shardNames) < 2 {
+		t.Skip("Test requires at least 2 shards")
+	}
+
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+	locationPath, locationWs := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+	locationWsName := logicalcluster.Name(locationWs.Spec.Cluster)
+
+	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithShard(shardNames[0]))
+	workloadWorkspace1Name := logicalcluster.Name(workloadWorkspace1.Spec.Cluster)
+
+	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithShard(shardNames[1]))
+	workloadWorkspace2Name := logicalcluster.Name(workloadWorkspace2.Spec.Cluster)
+
+	upstreamKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(upstreamConfig)
+	require.NoError(t, err)
+
+	// Creating synctarget and deploying the syncer
+	syncer := framework.NewSyncerFixture(t, upstreamServer, locationPath, framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2)).
+		CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+
+	t.Log("Binding workspace 1 to the location workspace")
+	framework.NewBindCompute(t, workloadWorkspace1Name.Path(), upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWsName.Path()),
+	).Bind(t)
+
+	t.Log("Binding workspace 2 to the location workspace")
+	framework.NewBindCompute(t, workloadWorkspace2Name.Path(), upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWsName.Path()),
+	).Bind(t)
+
+	err = framework.CreateResources(ctx, workspace1.FS, upstreamConfig, workloadWorkspace1Path)
+	require.NoError(t, err)
+
+	err = framework.CreateResources(ctx, workspace2.FS, upstreamConfig, workloadWorkspace2Path)
+	require.NoError(t, err)
+
+	downstreamWS1NS := syncer.DownstreamNamespaceFor(t, workloadWorkspace1Name, "default")
+	t.Logf("Downstream namespace in workspace 1 is %s", downstreamWS1NS)
+
+	downstreamWS2NS := syncer.DownstreamNamespaceFor(t, workloadWorkspace2Name, "default")
+	t.Logf("Downstream namespace in workspace 2 is %s", downstreamWS2NS)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)
+	require.NoError(t, err)
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		_, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS).Get(ctx, "test1", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test1 not found downstream"
+		}
+		require.NoError(t, err)
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "deployment test1 not synced downstream")
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		_, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS2NS).Get(ctx, "test2", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test2 not found downstream"
+		}
+		require.NoError(t, err)
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "deployment test1 not synced downstream")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS).ApplyStatus(ctx, appsv1apply.Deployment("test1", downstreamWS1NS).WithStatus(&appsv1apply.DeploymentStatusApplyConfiguration{
+				Replicas:          ptr(int32(1)),
+				UpdatedReplicas:   ptr(int32(1)),
+				AvailableReplicas: ptr(int32(1)),
+				ReadyReplicas:     ptr(int32(1)),
+			}), metav1.ApplyOptions{FieldManager: "e2e-test", Force: true})
+			return err
+		})
+		require.NoError(t, err)
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS2NS).ApplyStatus(ctx, appsv1apply.Deployment("test2", downstreamWS2NS).WithStatus(&appsv1apply.DeploymentStatusApplyConfiguration{
+				Replicas:          ptr(int32(1)),
+				UpdatedReplicas:   ptr(int32(1)),
+				AvailableReplicas: ptr(int32(0)),
+				ReadyReplicas:     ptr(int32(0)),
+			}), metav1.ApplyOptions{FieldManager: "e2e-test", Force: true})
+			return err
+		})
+		require.NoError(t, err)
+	}
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		test1Downstream, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS).Get(ctx, "test1", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test1 not found downstream"
+		}
+		require.NoError(t, err)
+
+		test1Upstream, err := upstreamKubeClusterClient.AppsV1().Cluster(workloadWorkspace1Path).Deployments("default").Get(ctx, "test1", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test1 not found upstream"
+		}
+		require.NoError(t, err)
+		diff := cmp.Diff(test1Downstream.Status, test1Upstream.Status)
+		return len(diff) == 0, fmt.Sprintf("status different between downstream and upstream: %s", diff)
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "status of deployment test1 not synced back upstream")
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		test2Downstream, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS2NS).Get(ctx, "test2", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test2 not found downstream"
+		}
+		require.NoError(t, err)
+
+		test2Upstream, err := upstreamKubeClusterClient.AppsV1().Cluster(workloadWorkspace2Path).Deployments("default").Get(ctx, "test2", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "deployment test1 not found upstream"
+		}
+		require.NoError(t, err)
+		diff := cmp.Diff(test2Downstream.Status, test2Upstream.Status)
+		return len(diff) == 0, fmt.Sprintf("status different between downstream and upstream: %s", diff)
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "status of deployment test2 not synced back upstream")
+}
+
+func ptr[T interface{}](val T) *T {
+	other := val
+	return &other
+}

--- a/test/e2e/syncer/multishard/workspace1/deployment.yaml
+++ b/test/e2e/syncer/multishard/workspace1/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+   name: test1
+   namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: test1
+          image: ghcr.io/distroless/busybox:latest
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Going to sleep"
+              tail -f /dev/null

--- a/test/e2e/syncer/multishard/workspace1/embed.go
+++ b/test/e2e/syncer/multishard/workspace1/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace1
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/multishard/workspace2/deployment.yaml
+++ b/test/e2e/syncer/multishard/workspace2/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+   name: test2
+   namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: test2
+          image: ghcr.io/distroless/busybox:latest
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Going to sleep"
+              tail -f /dev/null

--- a/test/e2e/syncer/multishard/workspace2/embed.go
+++ b/test/e2e/syncer/multishard/workspace2/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace2
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/persistentvolume.yaml
+++ b/test/e2e/syncer/persistentvolume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncer-test-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  nfs:
+    path: /tmp
+    server: 127.0.0.1
+  storageClassName: standard
+  volumeMode: Filesystem

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -1,0 +1,707 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	kubefixtures "github.com/kcp-dev/kcp/test/e2e/fixtures/kube"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+//go:embed *.yaml
+var embeddedResources embed.FS
+
+func TestSyncerLifecycle(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster")
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	t.Log("Creating an organization")
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	t.Log("Creating a workspace")
+	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+
+	// The Start method of the fixture will initiate syncer start and then wait for
+	// its sync target to go ready. This implicitly validates the syncer
+	// heartbeating and the heartbeat controller setting the sync target ready in
+	// response.
+	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsPath,
+		framework.WithExtraResources("persistentvolumes"),
+		framework.WithSyncedUserWorkspaces(ws),
+		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
+			if !isFakePCluster {
+				// Only need to install services and ingresses in a logical cluster
+				return
+			}
+			sinkCrdClient, err := apiextensionsclientset.NewForConfig(config)
+			require.NoError(t, err, "failed to create apiextensions client")
+			t.Logf("Installing test CRDs into sink cluster...")
+			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
+			)
+			require.NoError(t, err)
+		})).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	kcpClient, err := kcpclientset.NewForConfig(upstreamServer.BaseConfig(t))
+	require.NoError(t, err)
+	t.Logf("Waiting for negotiaged api to be generated...")
+	require.Eventually(t, func() bool {
+		negotiatedAPIs, err := kcpClient.Cluster(wsPath).ApiresourceV1alpha1().NegotiatedAPIResources().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		return len(negotiatedAPIs.Items) > 0
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "negotiaged apis are not generated")
+
+	t.Logf("Bind location workspace")
+	framework.NewBindCompute(t, wsPath, upstreamServer, framework.WithAPIExportsWorkloadBindOption("root:compute:kubernetes", workloadv1alpha1.ImportedAPISExportName)).Bind(t)
+
+	upstreamConfig := upstreamServer.BaseConfig(t)
+	upstreamKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(upstreamConfig)
+	require.NoError(t, err)
+
+	t.Log("Creating upstream namespace...")
+	upstreamNamespace, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-syncer",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncerFixture.DownstreamConfig)
+	require.NoError(t, err)
+
+	upstreamKcpClient, err := kcpclientset.NewForConfig(syncerFixture.SyncerConfig.UpstreamConfig)
+	require.NoError(t, err)
+
+	syncTarget, err := upstreamKcpClient.Cluster(syncerFixture.SyncerConfig.SyncTargetPath).WorkloadV1alpha1().SyncTargets().Get(ctx,
+		syncerFixture.SyncerConfig.SyncTargetName,
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	desiredNSLocator := shared.NewNamespaceLocator(logicalcluster.Name(ws.Spec.Cluster), logicalcluster.From(syncTarget),
+		syncTarget.GetUID(), syncTarget.Name, upstreamNamespace.Name)
+	downstreamNamespaceName, err := shared.PhysicalClusterNamespaceName(desiredNSLocator)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for downstream namespace to be created...")
+	require.Eventually(t, func() bool {
+		_, err = downstreamKubeClient.CoreV1().Namespaces().Get(ctx, downstreamNamespaceName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false
+			}
+			require.NoError(t, err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream namespace %s for upstream namespace %s was not created", downstreamNamespaceName, upstreamNamespace.Name)
+
+	configMapName := "kcp-root-ca.crt"
+	t.Logf("Waiting for downstream configmap %s/%s to be created...", downstreamNamespaceName, configMapName)
+	require.Eventually(t, func() bool {
+		_, err = downstreamKubeClient.CoreV1().ConfigMaps(downstreamNamespaceName).Get(ctx, configMapName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		if err != nil {
+			t.Errorf("saw an error waiting for downstream configmap %s/%s to be created: %v", downstreamNamespaceName, configMapName, err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream configmap %s/%s was not created", downstreamNamespaceName, configMapName)
+
+	t.Logf("Deleting the downstream kcp-root-ca.crt configmap to ensure it is recreated.")
+	err = downstreamKubeClient.CoreV1().ConfigMaps(downstreamNamespaceName).Delete(ctx, configMapName, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Waiting for downstream configmap %s/%s to be recreated...", downstreamNamespaceName, configMapName)
+	framework.Eventually(t, func() (bool, string) {
+		_, err = downstreamKubeClient.CoreV1().ConfigMaps(downstreamNamespaceName).Get(ctx, configMapName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, "not found"
+		}
+		if err != nil {
+			t.Errorf("saw an error waiting for downstream configmap %s/%s to be recreated: %v", downstreamNamespaceName, configMapName, err)
+			return false, "error getting configmap"
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream configmap %s/%s was not recreated", downstreamNamespaceName, configMapName)
+
+	t.Log("Creating upstream deployment...")
+
+	deploymentYAML, err := embeddedResources.ReadFile("deployment.yaml")
+	require.NoError(t, err, "failed to read embedded deployment")
+
+	var deployment *appsv1.Deployment
+	err = yaml.Unmarshal(deploymentYAML, &deployment)
+	require.NoError(t, err, "failed to unmarshal deployment")
+	t.Logf("unmarshalled into: %#v", deployment)
+
+	// This test created a new workspace that initially lacked support for deployments, but once the
+	// sync target went ready (checked by the syncer fixture's Start method) the api importer
+	// will have enabled deployments in the logical cluster.
+	t.Logf("Waiting for deployment to be created in upstream")
+	var upstreamDeployment *appsv1.Deployment
+	require.Eventually(t, func() bool {
+		upstreamDeployment, err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Create(ctx, deployment, metav1.CreateOptions{})
+		return err == nil
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "deployment not created")
+
+	t.Logf("difference between what we sent and what we got: %v", cmp.Diff(deployment, upstreamDeployment))
+
+	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name)
+
+	t.Logf("Waiting for upstream deployment %s/%s to get the syncer finalizer", upstreamNamespace.Name, upstreamDeployment.Name)
+	require.Eventually(t, func() bool {
+		deployment, err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		if err != nil {
+			t.Errorf("saw an error waiting for upstream deployment %s/%s to get the syncer finalizer: %v", upstreamNamespace.Name, upstreamDeployment.Name, err)
+		}
+		for _, finalizer := range deployment.Finalizers {
+			if finalizer == "workload.kcp.io/syncer-"+syncTargetKey {
+				return true
+			}
+		}
+		return false
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Upstream deployment %s/%s syncer finalizer was not added", upstreamNamespace.Name, upstreamDeployment.Name)
+
+	t.Logf("Waiting for downstream deployment %s/%s to be created...", downstreamNamespaceName, upstreamDeployment.Name)
+	require.Eventually(t, func() bool {
+		deployment, err = downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		if err != nil {
+			t.Errorf("saw an error waiting for downstream deployment %s/%s to be created: %v", downstreamNamespaceName, upstreamDeployment.Name, err)
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream deployment %s/%s was not synced", downstreamNamespaceName, upstreamDeployment.Name)
+
+	if len(framework.TestConfig.PClusterKubeconfig()) > 0 {
+		t.Logf("Check for available replicas if downstream is capable of actually running the deployment")
+		expectedAvailableReplicas := int32(1)
+		var lastEvents time.Time
+		framework.Eventually(t, func() (bool, string) {
+			deployment, err = downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			if actual, expected := deployment.Status.AvailableReplicas, expectedAvailableReplicas; actual != expected {
+				lastEvents = dumpPodEvents(t, lastEvents, downstreamKubeClient, downstreamNamespaceName)
+				return false, fmt.Sprintf("deployment had %d available replicas, not %d", actual, expected)
+			}
+			return true, ""
+		}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream deployment %s/%s didn't get available", downstreamNamespaceName, upstreamDeployment.Name)
+
+		// This test creates a deployment upstream, and will run downstream with a mutated projected
+		// in-cluster kubernetes config that points back to KCP. The running container will use this config to
+		// create a configmap upstream to verify the correctness of the mutation.
+		t.Logf("Create upstream service account permissions for downstream in-cluster configuration test")
+
+		configmapAdminRoleYAML, err := embeddedResources.ReadFile("configmap-admin-role.yaml")
+		require.NoError(t, err, "failed to read embedded role")
+
+		var configmapAdminRole *rbacv1.Role
+		err = yaml.Unmarshal(configmapAdminRoleYAML, &configmapAdminRole)
+		require.NoError(t, err, "failed to unmarshal role")
+
+		_, err = upstreamKubeClusterClient.Cluster(wsPath).RbacV1().Roles(upstreamNamespace.Name).Create(ctx, configmapAdminRole, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create upstream role")
+
+		configmapAdminRoleBindingYAML, err := embeddedResources.ReadFile("configmap-admin-rolebinding.yaml")
+		require.NoError(t, err, "failed to read embedded rolebinding")
+
+		var configmapAdminRoleBinding *rbacv1.RoleBinding
+		err = yaml.Unmarshal(configmapAdminRoleBindingYAML, &configmapAdminRoleBinding)
+		require.NoError(t, err, "failed to unmarshal rolebinding")
+
+		_, err = upstreamKubeClusterClient.Cluster(wsPath).RbacV1().RoleBindings(upstreamNamespace.Name).Create(ctx, configmapAdminRoleBinding, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create upstream rolebinding")
+
+		t.Logf("Creating upstream in-cluster configuration test deployment")
+
+		iccDeploymentYAML, err := embeddedResources.ReadFile("in-cluster-config-test-deployment.yaml")
+		require.NoError(t, err, "failed to read embedded deployment")
+
+		var iccDeployment *appsv1.Deployment
+		err = yaml.Unmarshal(iccDeploymentYAML, &iccDeployment)
+		require.NoError(t, err, "failed to unmarshal deployment")
+		iccDeployment.Spec.Template.Spec.Containers[0].Image = framework.TestConfig.KCPTestImage()
+		expectedConfigMapName := "expected-configmap"
+		iccDeployment.Spec.Template.Spec.Containers[0].Env[0].Value = expectedConfigMapName
+
+		iccUpstreamDeployment, err := upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Create(ctx, iccDeployment, metav1.CreateOptions{})
+		require.NoError(t, err, "failed to create icc-test deployment")
+
+		t.Logf("Waiting for downstream in-cluster config test deployment %s/%s to be created...", downstreamNamespaceName, iccUpstreamDeployment.Name)
+		var logState map[string]*metav1.Time
+		framework.Eventually(t, func() (bool, string) {
+			deployment, err = downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, iccUpstreamDeployment.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false, ""
+			}
+			require.NoError(t, err)
+			dumpPodEvents(t, lastEvents, downstreamKubeClient, downstreamNamespaceName)
+			logState = dumpPodLogs(t, logState, downstreamKubeClient, downstreamNamespaceName)
+			if actual, expected := deployment.Status.AvailableReplicas, int32(1); actual != expected {
+				return false, fmt.Sprintf("deployment had %d available replicas, not %d", actual, expected)
+			}
+			return true, ""
+		}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream deployment %s/%s was not synced", downstreamNamespaceName, iccUpstreamDeployment.Name)
+
+		t.Logf("Waiting for configmap generated by icc-test deployment to show up upstream")
+		require.Eventually(t, func() bool {
+			logState = dumpPodLogs(t, logState, downstreamKubeClient, downstreamNamespaceName)
+
+			_, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().ConfigMaps(upstreamNamespace.Name).Get(ctx, expectedConfigMapName, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false
+			}
+			require.NoError(t, err)
+			return true
+		}, wait.ForeverTestTimeout, time.Millisecond*100, "upstream configmap %s/%s was not found", upstreamNamespace.Name, expectedConfigMapName)
+	}
+	// Delete the deployment
+	err = downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Delete(ctx, deployment.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	// Wait the deployment to be recreated and check it is a different UID
+	t.Logf("Waiting for downstream deployment %s/%s to be created...", downstreamNamespaceName, upstreamDeployment.Name)
+	require.Eventually(t, func() bool {
+		newDeployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		require.NoError(t, err)
+		return deployment.UID != newDeployment.UID
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream deployment %s/%s was not synced", downstreamNamespaceName, upstreamDeployment.Name)
+
+	// Add a virtual Finalizer to the deployment and update it.
+	t.Logf("Adding a virtual finalizer to the upstream deployment %s/%s in order to simulate an external controller", upstreamNamespace.Name, upstreamDeployment.Name)
+	deploymentPatch := []byte(`{"metadata":{"annotations":{"finalizers.workload.kcp.io/` + syncTargetKey + `":"external-controller-finalizer"}}}`)
+	_, err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Patch(ctx, upstreamDeployment.Name, types.MergePatchType, deploymentPatch, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Deleting upstream deployment %s/%s", upstreamNamespace.Name, upstreamDeployment.Name)
+	err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Delete(ctx, upstreamDeployment.Name, metav1.DeleteOptions{GracePeriodSeconds: pointer.Int64(0)})
+	require.NoError(t, err)
+
+	t.Logf("Checking if the upstream deployment %s/%s has the per-location deletion annotation set", upstreamNamespace.Name, upstreamDeployment.Name)
+	framework.Eventually(t, func() (bool, string) {
+		deployment, err := upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, ""
+		}
+		require.NoError(t, err)
+		if val, ok := deployment.GetAnnotations()["deletion.internal.workload.kcp.io/"+syncTargetKey]; !ok || val == "" {
+			return false, fmt.Sprintf("deployment did not have the %s annotation", "deletion.internal.workload.kcp.io/"+syncTargetKey)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "upstream Deployment %s/%s didn't get the per-location deletion annotation set or there was an error", upstreamNamespace.Name, upstreamDeployment.Name)
+
+	t.Logf("Checking if upstream deployment %s/%s is deleted, shouldn't as the syncer will not remove its finalizer due to the virtual finalizer", upstreamNamespace.Name, upstreamDeployment.Name)
+	_, err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+	require.False(t, apierrors.IsNotFound(err))
+	require.NoError(t, err)
+
+	t.Logf("Checking if the downstream deployment %s/%s is deleted or not (shouldn't as there's a virtual finalizer that blocks the deletion of the downstream resource)", downstreamNamespaceName, upstreamDeployment.Name)
+	_, err = downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+	require.False(t, apierrors.IsNotFound(err))
+	require.NoError(t, err)
+
+	t.Logf("Deleting upstream namespace %s", upstreamNamespace.Name)
+	err = upstreamKubeClusterClient.Cluster(wsPath).CoreV1().Namespaces().Delete(ctx, upstreamNamespace.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Checking if upstream namespace %s deletion timestamp is set", upstreamNamespace.Name)
+	framework.Eventually(t, func() (bool, string) {
+		namespace, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().Namespaces().Get(ctx, upstreamNamespace.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		if namespace.DeletionTimestamp == nil {
+			return false, "namespace deletion timestamp is not set"
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "upstream Namespace %s was not deleted", upstreamNamespace.Name)
+
+	t.Logf("Checking if downstream namespace %s is marked for deletion or deleted, shouldn't as there's a deployment with a virtual finalizer", downstreamNamespaceName)
+	require.Neverf(t, func() bool {
+		namespace, err := downstreamKubeClient.CoreV1().Namespaces().Get(ctx, downstreamNamespaceName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		require.NoError(t, err)
+		return namespace.DeletionTimestamp != nil
+	}, 5*time.Second, time.Millisecond*100, "downstream Namespace %s was marked for deletion or deleted", downstreamNamespaceName)
+
+	// deleting a virtual Finalizer on the deployment and updating it.
+	t.Logf("Removing the virtual finalizer on the upstream deployment %s/%s, the deployment deletion should go through after this", upstreamNamespace.Name, upstreamDeployment.Name)
+	deploymentPatch = []byte(`{"metadata":{"annotations":{"finalizers.workload.kcp.io/` + syncTargetKey + `": null}}}`)
+	_, err = upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Patch(ctx, upstreamDeployment.Name, types.MergePatchType, deploymentPatch, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Waiting for upstream deployment %s/%s to be deleted", upstreamNamespace.Name, upstreamDeployment.Name)
+	require.Eventually(t, func() bool {
+		_, err := upstreamKubeClusterClient.Cluster(wsPath).AppsV1().Deployments(upstreamNamespace.Name).Get(ctx, upstreamDeployment.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		require.NoError(t, err)
+		return false
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "upstream Deployment %s/%s was not deleted", upstreamNamespace.Name, upstreamDeployment.Name)
+
+	t.Logf("Waiting for downstream namespace %s to be marked for deletion or deleted", downstreamNamespaceName)
+	framework.Eventually(t, func() (bool, string) {
+		namespace, err := downstreamKubeClient.CoreV1().Namespaces().Get(ctx, downstreamNamespaceName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, "namespace was deleted"
+		}
+		require.NoError(t, err)
+		if namespace.DeletionTimestamp != nil {
+			return true, "deletionTimestamp is set."
+		}
+		return false, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream Namespace %s was not marked for deletion or deleted", downstreamNamespaceName)
+
+	t.Logf("Creating Persistent Volume to test cluster-wide resource syncing")
+	pvYAML, err := embeddedResources.ReadFile("persistentvolume.yaml")
+	require.NoError(t, err, "failed to read embedded persistenvolume")
+
+	var persistentVolume *corev1.PersistentVolume
+	err = yaml.Unmarshal(pvYAML, &persistentVolume)
+	require.NoError(t, err, "failed to unmarshal persistentvolume")
+
+	upstreamPersistentVolume, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().PersistentVolumes().Create(ctx, persistentVolume, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create persistentVolume")
+
+	t.Logf("Waiting for the Persistent Volume to be scheduled upstream")
+	framework.Eventually(t, func() (bool, string) {
+		pv, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().PersistentVolumes().Get(ctx, upstreamPersistentVolume.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if val, ok := pv.GetLabels()["state.workload.kcp.io/"+syncTargetKey]; ok {
+			if val != "" {
+				return false, "state label is not empty, should be."
+			}
+			return true, ""
+		}
+		return false, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Persistent Volume %s was not scheduled", upstreamPersistentVolume.Name)
+
+	t.Logf("Updating the PV to be force it to be scheduled downstream")
+	pvPatch := []byte(`{"metadata":{"labels":{"state.workload.kcp.io/` + syncTargetKey + `": "Sync"}}}`)
+	_, err = upstreamKubeClusterClient.Cluster(wsPath).CoreV1().PersistentVolumes().Patch(ctx, upstreamPersistentVolume.Name, types.MergePatchType, pvPatch, metav1.PatchOptions{})
+	require.NoError(t, err, "failed to patch persistentVolume")
+
+	t.Logf("Waiting for the Persistent Volume to be synced downstream and validate its NamespceLocator")
+	framework.Eventually(t, func() (bool, string) {
+		pv, err := downstreamKubeClient.CoreV1().PersistentVolumes().Get(ctx, upstreamPersistentVolume.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if val := pv.GetAnnotations()[shared.NamespaceLocatorAnnotation]; val != "" {
+			desiredNSLocator.Namespace = ""
+			desiredNSLocatorByte, err := json.Marshal(desiredNSLocator)
+			require.NoError(t, err, "failed to marshal namespaceLocator")
+			if string(desiredNSLocatorByte) != val {
+				return false, "namespaceLocator for persistentVolume doesn't match the expected one"
+			}
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Persistent Volume %s was not synced downstream", upstreamPersistentVolume.Name)
+
+	t.Logf("Deleting the Persistent Volume upstream")
+	err = upstreamKubeClusterClient.Cluster(wsPath).CoreV1().PersistentVolumes().Delete(ctx, upstreamPersistentVolume.Name, metav1.DeleteOptions{})
+	require.NoError(t, err, "failed to delete persistentVolume upstream")
+
+	t.Logf("Waiting for the Persistent Volume to be deleted upstream")
+	framework.Eventually(t, func() (bool, string) {
+		_, err := upstreamKubeClusterClient.Cluster(wsPath).CoreV1().PersistentVolumes().Get(ctx, upstreamPersistentVolume.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, ""
+		}
+		require.NoError(t, err)
+		return false, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Persistent Volume %s was not deleted upstream", upstreamPersistentVolume.Name)
+
+	t.Logf("Waiting for the Persistent Volume to be deleted downstream")
+	framework.Eventually(t, func() (bool, string) {
+		pv, err := downstreamKubeClient.CoreV1().PersistentVolumes().Get(ctx, upstreamPersistentVolume.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, "pv is not found"
+		}
+		if pv.DeletionTimestamp != nil {
+			return true, "deletionTimestamp is set."
+		}
+		require.NoError(t, err)
+		return false, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Persistent Volume %s was not deleted downstream", upstreamPersistentVolume.Name)
+}
+
+func dumpPodEvents(t *testing.T, startAfter time.Time, downstreamKubeClient kubernetes.Interface, downstreamNamespaceName string) time.Time {
+	t.Helper()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	eventList, err := downstreamKubeClient.CoreV1().Events(downstreamNamespaceName).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("Error getting events: %v", err)
+		return startAfter // ignore. Error here are not the ones we care for.
+	}
+
+	sort.Slice(eventList.Items, func(i, j int) bool {
+		return eventList.Items[i].LastTimestamp.Time.Before(eventList.Items[j].LastTimestamp.Time)
+	})
+
+	last := startAfter
+	for _, event := range eventList.Items {
+		if event.InvolvedObject.Kind != "Pod" {
+			continue
+		}
+		if event.LastTimestamp.After(startAfter) {
+			t.Logf("Event for pod %s/%s: %s", event.InvolvedObject.Namespace, event.InvolvedObject.Name, event.Message)
+		}
+		if event.LastTimestamp.After(last) {
+			last = event.LastTimestamp.Time
+		}
+	}
+
+	pods, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespaceName).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("Error getting pods: %v", err)
+		return last // ignore. Error here are not the ones we care for.
+	}
+
+	for _, pod := range pods.Items {
+		for _, s := range pod.Status.ContainerStatuses {
+			if s.State.Terminated != nil && s.State.Terminated.FinishedAt.After(startAfter) {
+				t.Logf("Pod %s/%s container %s terminated with exit code %d: %s", pod.Namespace, pod.Name, s.Name, s.State.Terminated.ExitCode, s.State.Terminated.Message)
+			}
+		}
+	}
+
+	return last
+}
+
+func dumpPodLogs(t *testing.T, startAfter map[string]*metav1.Time, downstreamKubeClient kubernetes.Interface, downstreamNamespaceName string) map[string]*metav1.Time {
+	t.Helper()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	if startAfter == nil {
+		startAfter = make(map[string]*metav1.Time)
+	}
+
+	pods, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespaceName).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("Error getting pods: %v", err)
+		return startAfter // ignore. Error here are not the ones we care for.
+	}
+	for _, pod := range pods.Items {
+		for _, c := range pod.Spec.Containers {
+			key := fmt.Sprintf("%s/%s", pod.Name, c.Name)
+			now := metav1.Now()
+			res, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespaceName).GetLogs(pod.Name, &corev1.PodLogOptions{
+				SinceTime: startAfter[key],
+				Container: c.Name,
+			}).DoRaw(ctx)
+			if err != nil {
+				t.Logf("Failed to get logs for pod %s/%s container %s: %v", pod.Namespace, pod.Name, c.Name, err)
+				continue
+			}
+			for _, line := range strings.Split(string(res), "\n") {
+				t.Logf("Pod %s/%s container %s: %s", pod.Namespace, pod.Name, c.Name, line)
+			}
+			startAfter[key] = &now
+		}
+	}
+
+	return startAfter
+}
+
+func TestSyncWorkload(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster")
+
+	syncTargetName := "test-wlc"
+	upstreamServer := framework.SharedKcpServer(t)
+
+	t.Log("Creating an organization")
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	t.Log("Creating a workspace")
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+
+	// Write the upstream logical cluster config to disk for the workspace plugin
+	upstreamRawConfig, err := upstreamServer.RawConfig()
+	require.NoError(t, err)
+	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, "base", wsPath)
+
+	subCommand := []string{
+		"workload",
+		"sync",
+		syncTargetName,
+		"--syncer-image",
+		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
+		"--output-file", "-",
+	}
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommand)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommand)
+}
+
+func TestCordonUncordonDrain(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster")
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	t.Log("Creating an organization")
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	upstreamCfg := upstreamServer.BaseConfig(t)
+
+	t.Log("Creating a workspace")
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+
+	// Write the upstream logical cluster config to disk for the workspace plugin
+	upstreamRawConfig, err := upstreamServer.RawConfig()
+	require.NoError(t, err)
+	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, "base", wsPath)
+
+	kcpClusterClient, err := kcpclientset.NewForConfig(upstreamCfg)
+	require.NoError(t, err, "failed to construct client for server")
+
+	// The Start method of the fixture will initiate syncer start and then wait for
+	// its sync target to go ready. This implicitly validates the syncer
+	// heartbeating and the heartbeat controller setting the sync target ready in
+	// response.
+	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsPath).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+	syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	t.Log("Check initial workload")
+	cluster, err := kcpClusterClient.Cluster(wsPath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get sync target", syncTargetName)
+	require.False(t, cluster.Spec.Unschedulable)
+	require.Nil(t, cluster.Spec.EvictAfter)
+
+	t.Log("Cordon workload")
+	subCommandCordon := []string{
+		"workload",
+		"cordon",
+		syncTargetName,
+	}
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandCordon)
+
+	t.Log("Check workload after cordon")
+	cluster, err = kcpClusterClient.Cluster(wsPath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get sync target", syncTargetName)
+	require.True(t, cluster.Spec.Unschedulable)
+	require.Nil(t, cluster.Spec.EvictAfter)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandCordon)
+
+	t.Log("Uncordon workload")
+	subCommandUncordon := []string{
+		"workload",
+		"uncordon",
+		syncTargetName,
+	}
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandUncordon)
+
+	t.Log("Check workload after uncordon")
+	cluster, err = kcpClusterClient.Cluster(wsPath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get sync target", syncTargetName)
+	require.False(t, cluster.Spec.Unschedulable)
+	require.Nil(t, cluster.Spec.EvictAfter)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandUncordon)
+
+	t.Log("Drain workload")
+	subCommandDrain := []string{
+		"workload",
+		"drain",
+		syncTargetName,
+	}
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandDrain)
+
+	t.Log("Check workload after drain started")
+	cluster, err = kcpClusterClient.Cluster(wsPath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get sync target", syncTargetName)
+	require.True(t, cluster.Spec.Unschedulable)
+	require.NotNil(t, cluster.Spec.EvictAfter)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandDrain)
+
+	t.Log("Remove drain, uncordon workload")
+	subCommandUncordon = []string{
+		"workload",
+		"uncordon",
+		syncTargetName,
+	}
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommandUncordon)
+
+	t.Log("Check workload after uncordon")
+	cluster, err = kcpClusterClient.Cluster(wsPath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get sync target", syncTargetName)
+	require.False(t, cluster.Spec.Unschedulable)
+	require.Nil(t, cluster.Spec.EvictAfter)
+}

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -1,0 +1,472 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	corev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
+	kcpclientset "github.com/kcp-dev/kcp/sdk/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestSyncerTunnel(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		t.Skip("Test requires a pcluster")
+	}
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	t.Log("Creating an organization")
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+	t.Logf("Creating one workspace for the synctarget on shard %q ", corev1alpha1.RootShard)
+	synctargetWsPath, synctargetWs := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithRootShard())
+	synctargetWsName := logicalcluster.Name(synctargetWs.Spec.Cluster)
+
+	userWSShardName := corev1alpha1.RootShard
+	shardNames := upstreamServer.ShardNames()
+	if len(shardNames) > 1 {
+		userWSShardName = shardNames[1]
+	}
+
+	t.Logf("Creating one workspace for the synctarget on shard %q ", userWSShardName)
+	userWsPath, userWs := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithShard(userWSShardName))
+	userWsName := logicalcluster.Name(userWs.Spec.Cluster)
+
+	// The Start method of the fixture will initiate syncer start and then wait for
+	// its sync target to go ready. This implicitly validates the syncer
+	// heartbeating and the heartbeat controller setting the sync target ready in
+	// response.
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, synctargetWsName.Path(),
+		framework.WithSyncedUserWorkspaces(userWs),
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+
+	syncerFixture.WaitForSyncTargetReady(ctx, t)
+
+	t.Log("Binding the consumer workspace to the location workspace")
+	framework.NewBindCompute(t, userWsName.Path(), upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(synctargetWsName.Path()),
+	).Bind(t)
+
+	upstreamConfig := upstreamServer.BaseConfig(t)
+	upstreamKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(upstreamConfig)
+	require.NoError(t, err)
+
+	// From now on, we'll be using the user-1 credentials to interact with the workspace etc. This is done to
+	// simulate a user that is not kcp-admin and to make sure that it can access the logs of a pod through a synctarget
+	// that is in another workspace.
+	clusterAdminUser := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin-user-1"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "user-1"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io",
+			Kind: "ClusterRole", Name: "cluster-admin"},
+	}
+
+	_, err = upstreamKubeClusterClient.Cluster(userWsPath).RbacV1().ClusterRoleBindings().Create(ctx, clusterAdminUser, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a client using the user-1 token.
+	userConfig := framework.ConfigWithToken("user-1-token", upstreamServer.BaseConfig(t))
+	userKcpClient, err := kcpkubernetesclientset.NewForConfig(userConfig)
+	require.NoError(t, err)
+
+	t.Log("Creating upstream namespace...")
+	require.Eventually(t, func() bool {
+		_, err := userKcpClient.Cluster(userWsPath).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-syncer",
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return true
+			}
+			t.Errorf("saw an error creating upstream namespace: %v", err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "upstream namespace was not created")
+
+	upstreamNamespaceName := "test-syncer"
+
+	require.NoError(t, err)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncerFixture.DownstreamConfig)
+	require.NoError(t, err)
+
+	upstreamKcpClient, err := kcpclientset.NewForConfig(syncerFixture.SyncerConfig.UpstreamConfig)
+	require.NoError(t, err)
+
+	syncTarget, err := upstreamKcpClient.Cluster(synctargetWsPath).WorkloadV1alpha1().SyncTargets().Get(ctx,
+		syncerFixture.SyncerConfig.SyncTargetName,
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	desiredNSLocator := shared.NewNamespaceLocator(userWsName, synctargetWsName,
+		syncTarget.GetUID(), syncTarget.Name, upstreamNamespaceName)
+	require.NoError(t, err)
+
+	downstreamNamespaceName, err := shared.PhysicalClusterNamespaceName(desiredNSLocator)
+	require.NoError(t, err)
+
+	t.Logf("Waiting for downstream namespace to be created...")
+	require.Eventually(t, func() bool {
+		_, err = downstreamKubeClient.CoreV1().Namespaces().Get(ctx, downstreamNamespaceName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false
+			}
+			require.NoError(t, err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream namespace %s for upstream namespace %s was not created", downstreamNamespaceName, upstreamNamespaceName)
+
+	configMapName := "kcp-root-ca.crt"
+	t.Logf("Waiting for downstream configmap %s/%s to be created...", downstreamNamespaceName, configMapName)
+	require.Eventually(t, func() bool {
+		_, err = downstreamKubeClient.CoreV1().ConfigMaps(downstreamNamespaceName).Get(ctx, configMapName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		if err != nil {
+			t.Errorf("saw an error waiting for downstream configmap %s/%s to be created: %v", downstreamNamespaceName, configMapName, err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream configmap %s/%s was not created", downstreamNamespaceName, configMapName)
+
+	t.Log("Wait for being able to list deployments in the consumer workspace via direct access")
+	require.Eventually(t, func() bool {
+		_, err := userKcpClient.Cluster(userWsPath).AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		} else if err != nil {
+			t.Log(t, "Failed to list deployments: %v", err)
+			return false
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	t.Log("Creating upstream Deployment ...")
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tunnel-test",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "busybox",
+							Image:   "ghcr.io/distroless/busybox:1.35.0-r23",
+							Command: []string{"/bin/sh", "-c", `date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; sleep 1; done`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = userKcpClient.Cluster(userWsPath).AppsV1().Deployments(upstreamNamespaceName).Create(ctx, d, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Waiting for downstream Deployment to be ready ...")
+	framework.Eventually(t, func() (bool, string) {
+		deployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamNamespaceName).Get(ctx, d.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err.Error()
+		}
+		if deployment.Status.ReadyReplicas != 1 {
+			return false, fmt.Sprintf("expected 1 ready replica, got %d", deployment.Status.ReadyReplicas)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	// Get the downstream deployment POD name
+	pods, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespaceName).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 1)
+
+	// Upsync the downstream deployment POD to KCP
+	pod := pods.Items[0]
+	pod.ObjectMeta.GenerateName = ""
+	pod.Namespace = upstreamNamespaceName
+	pod.ResourceVersion = ""
+	pod.OwnerReferences = nil
+
+	labels := pod.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["state.workload.kcp.io/"+workloadv1alpha1.ToSyncTargetKey(synctargetWsName, syncTarget.Name)] = "Upsync"
+	pod.SetLabels(labels)
+
+	// Try to create the pod in KCP, it should fail because the user doesn't have the right permissions
+	_, err = userKcpClient.Cluster(userWsPath).CoreV1().Pods(upstreamNamespaceName).Create(ctx, &pod, metav1.CreateOptions{})
+	require.EqualError(t, err, "pods is forbidden: User \"user-1\" cannot create resource \"pods\" in API group \"\" in the namespace \"test-syncer\": access denied")
+
+	t.Log("Waiting for the upsyncing of the PODs to KCP")
+	framework.Eventually(t, func() (bool, string) {
+		pods, err = userKcpClient.Cluster(userWsPath).CoreV1().Pods(upstreamNamespaceName).List(ctx, metav1.ListOptions{
+			LabelSelector: "foo=bar",
+		})
+		if apierrors.IsUnauthorized(err) {
+			return false, fmt.Sprintf("failed to list pods: %v", err)
+		}
+		require.NoError(t, err)
+
+		return pods != nil && len(pods.Items) > 0, "upsynced pods not found"
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "couldn't get upstream pods for deployment %s/%s", d.Namespace, d.Name)
+
+	t.Logf("Getting Pod logs from upstream cluster %q as a normal kubectl client would do.", userWs.Name)
+	framework.Eventually(t, func() (bool, string) {
+		var podLogs bytes.Buffer
+		for _, pod := range pods.Items {
+			request := userKcpClient.Cluster(userWsPath).CoreV1().Pods(upstreamNamespaceName).GetLogs(pod.Name, &corev1.PodLogOptions{})
+			logs, err := request.Do(ctx).Raw()
+			if err != nil {
+				return false, err.Error()
+			}
+			podLogs.Write(logs)
+		}
+
+		return podLogs.Len() > 1, podLogs.String()
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "couldn't get downstream pod logs for deployment %s/%s", d.Namespace, d.Name)
+}
+
+// TestSyncerTunnelFilter ensures that the syncer tunnel will reject trying to access a Pod that is crafted and not actually upsynced.
+func TestSyncerTunnelFilter(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster")
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	kcpServer := framework.SharedKcpServer(t)
+	orgPath, _ := framework.NewOrganizationFixture(t, kcpServer, framework.TODO_WithoutMultiShardSupport())
+	locationPath, locationWs := framework.NewWorkspaceFixture(t, kcpServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+	locationWsName := logicalcluster.Name(locationWs.Spec.Cluster)
+	userPath, userWs := framework.NewWorkspaceFixture(t, kcpServer, orgPath, framework.TODO_WithoutMultiShardSupport())
+	userWsName := logicalcluster.Name(userWs.Spec.Cluster)
+
+	// Creating synctarget and deploying the syncer
+	syncerFixture := framework.NewSyncerFixture(t, kcpServer, locationPath, framework.WithSyncedUserWorkspaces(userWs)).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
+	syncerFixture.StartSyncerTunnel(t)
+
+	t.Log("Binding the consumer workspace to the location workspace")
+	framework.NewBindCompute(t, userWsName.Path(), kcpServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWsName.Path()),
+	).Bind(t)
+
+	kcpClient, err := kcpclientset.NewForConfig(kcpServer.BaseConfig(t))
+	require.NoError(t, err)
+
+	syncTarget, err := kcpClient.Cluster(syncerFixture.SyncerConfig.SyncTargetPath).WorkloadV1alpha1().SyncTargets().Get(ctx,
+		syncerFixture.SyncerConfig.SyncTargetName,
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	kcpKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpServer.BaseConfig(t))
+	require.NoError(t, err)
+
+	downstreamKubeLikeClient, err := kubernetes.NewForConfig(syncerFixture.SyncerConfig.DownstreamConfig)
+	require.NoError(t, err)
+
+	upstreamNs, err := kcpKubeClusterClient.CoreV1().Namespaces().Cluster(userPath).Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-syncer",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	nsLocator := shared.NamespaceLocator{
+		SyncTarget: shared.SyncTargetLocator{
+			ClusterName: string(logicalcluster.From(syncTarget)),
+			Name:        syncTarget.Name,
+			UID:         syncTarget.UID,
+		},
+		ClusterName: logicalcluster.From(upstreamNs),
+		Namespace:   upstreamNs.Name,
+	}
+
+	downstreamNsName, err := shared.PhysicalClusterNamespaceName(nsLocator)
+	require.NoError(t, err)
+
+	// Convert the locator to json, as we need to set it on the namespace.
+	locatorJSON, err := json.Marshal(nsLocator)
+	require.NoError(t, err)
+
+	// Create a namespace on the downstream cluster that matches the kcp namespace, with a correct locator.
+	_, err = downstreamKubeLikeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: downstreamNsName,
+			Labels: map[string]string{
+				workloadv1alpha1.InternalDownstreamClusterLabel: workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name),
+			},
+			Annotations: map[string]string{
+				shared.NamespaceLocatorAnnotation: string(locatorJSON),
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a pod downstream that is not upsynced, to ensure that the syncer tunnel will reject it.
+	_, err = downstreamKubeLikeClient.CoreV1().Pods(downstreamNsName).Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			Finalizers: []string{
+				shared.SyncerFinalizerNamePrefix + workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name),
+			},
+			Labels: map[string]string{
+				workloadv1alpha1.InternalDownstreamClusterLabel: workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name): "",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test",
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a pod on the upstream namespace that looks like the downstream pod being upsynced.
+	upsyncerVirtualWorkspaceConfig := rest.CopyConfig(kcpServer.BaseConfig(t))
+	framework.Eventually(t, func() (found bool, _ string) {
+		var err error
+		upsyncerVirtualWorkspaceConfig.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClient, userWs, syncerFixture.GetUpsyncerVirtualWorkspaceURLs())
+		require.NoError(t, err)
+		return found, "Upsyncer virtual workspace URL not found"
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "Upsyncer virtual workspace URL not found")
+	upsyncedClient, err := kcpkubernetesclientset.NewForConfig(upsyncerVirtualWorkspaceConfig)
+	require.NoError(t, err)
+
+	upsyncedPod, err := upsyncedClient.CoreV1().Pods().Cluster(userWsName.Path()).Namespace(upstreamNs.Name).Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-pod",
+			Finalizers: []string{},
+			Labels: map[string]string{
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + workloadv1alpha1.ToSyncTargetKey(logicalcluster.From(syncTarget), syncTarget.Name): "Upsync",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "test",
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	framework.Eventually(t, func() (bool, string) {
+		expectedError := fmt.Sprintf("unknown (get pods %s)", upsyncedPod.Name)
+		request := kcpKubeClusterClient.Cluster(userWsName.Path()).CoreV1().Pods(upstreamNs.Name).GetLogs(upsyncedPod.Name, &corev1.PodLogOptions{})
+		_, err = request.Do(ctx).Raw()
+		if err != nil {
+			if err.Error() == expectedError {
+				return true, ""
+			}
+			return false, fmt.Sprintf("Returned error: %s is different from expected error: %s", err.Error(), expectedError)
+		}
+		return false, "no error returned from get logs"
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "")
+
+	// Update the downstream namespace locator to point to another synctarget.
+	locatorJSON, err = json.Marshal(shared.NamespaceLocator{
+		SyncTarget: shared.SyncTargetLocator{
+			ClusterName: "another-cluster",
+			Name:        "another-sync-target",
+			UID:         "another-sync-target-uid",
+		},
+		ClusterName: logicalcluster.From(upstreamNs),
+		Namespace:   upstreamNs.Name,
+	})
+	require.NoError(t, err)
+
+	// Get a more privileged client to be able to update namespaces.
+	downstreamAdminKubeClient, err := kubernetes.NewForConfig(syncerFixture.DownstreamConfig)
+	require.NoError(t, err)
+
+	// Patch the namespace to update the locator.
+	namespacePatch, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				shared.NamespaceLocatorAnnotation: string(locatorJSON),
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = downstreamAdminKubeClient.CoreV1().Namespaces().Patch(ctx, downstreamNsName, types.MergePatchType, namespacePatch, metav1.PatchOptions{})
+	require.NoError(t, err)
+
+	// Let's try to get the pod logs again, this should fail, as the downstream Pod is not actually upsynced.
+	framework.Eventually(t, func() (bool, string) {
+		expectedError := fmt.Sprintf("unknown (get pods %s)", upsyncedPod.Name)
+		request := kcpKubeClusterClient.Cluster(userWsName.Path()).CoreV1().Pods(upstreamNs.Name).GetLogs(upsyncedPod.Name, &corev1.PodLogOptions{})
+		_, err = request.Do(ctx).Raw()
+		if err != nil {
+			if err.Error() == expectedError {
+				return true, ""
+			}
+			return false, fmt.Sprintf("Returned error: %s is different from expected error: %s", err.Error(), expectedError)
+		}
+		return false, "no error returned from get logs"
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "")
+}


### PR DESCRIPTION
## Summary
- restore syncer packages from `main-pre-tmc-removal`
- add pluggable module interfaces for future syncer extensions
- document legacy syncer layout and new design

## Testing
- `go test ./cmd/syncer/... ./pkg/syncer/...` *(fails: no required module provides some packages)*

------
https://chatgpt.com/codex/tasks/task_e_686df98fa3348324ab539d91c411a0af